### PR TITLE
Support --dropdb option when delete a cloud app

### DIFF
--- a/packages/dbos-cloud/applications/delete-app.ts
+++ b/packages/dbos-cloud/applications/delete-app.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosError } from "axios";
 import { isCloudAPIErrorResponse, handleAPIErrors, getCloudCredentials, getLogger, retrieveApplicationName } from "../cloudutils.js";
 
-export async function deleteApp(host: string, appName?: string): Promise<number> {
+export async function deleteApp(host: string, dropdb: boolean, appName?: string): Promise<number> {
   const logger = getLogger()
   const userCredentials = getCloudCredentials();
   const bearerToken = "Bearer " + userCredentials.token;
@@ -17,6 +17,9 @@ export async function deleteApp(host: string, appName?: string): Promise<number>
       headers: {
         "Content-Type": "application/json",
         Authorization: bearerToken,
+      },
+      data: {
+        "dropdb": dropdb,
       },
     });
 

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -132,8 +132,9 @@ applicationCommands
   .command('delete')
   .description('Delete this application')
   .argument('[string]', 'application name')
-  .action(async (appName?: string) => {
-    const exitCode = await deleteApp(DBOSCloudHost, appName);
+  .option('--dropdb', 'Drop application database')
+  .action(async (appName: string | undefined, options: { dropdb: boolean }) => {
+    const exitCode = await deleteApp(DBOSCloudHost, options.dropdb, appName);
     process.exit(exitCode);
   });
 


### PR DESCRIPTION
Add a `--dropdb` option so users can optionally drop the app's logical DB when they delete the app.
This option should be used with cautious.