### PR TITLE
Make CORS configurable / optional

### DIFF
--- a/dbos-config.schema.json
+++ b/dbos-config.schema.json
@@ -113,6 +113,24 @@
         }
       }
     },
+    "http": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cors_middleware": {
+          "type": "boolean"
+        },
+        "credentials": {
+          "type": "boolean"
+        },
+        "allowed_origins": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "application": {},
     "dbClientMetadata": {}
   },

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -58,6 +58,11 @@ export interface DBOSConfig {
   readonly application?: object;
   readonly dbClientMetadata?: any;
   readonly debugProxy?: string;
+  readonly http?: {
+    readonly cors_middleware?: boolean;
+    readonly credentials?: boolean;
+    readonly allowed_origins?: string[];
+  };
 }
 
 interface WorkflowInfo {

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -26,6 +26,11 @@ export interface ConfigFile {
     migrate?: string[];
     rollback?: string[];
   };
+  http?: {
+    cors_middleware?: boolean;
+    credentials?: boolean;
+    allowed_origins?: string[];
+  };
   telemetry?: TelemetryConfig;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   application: any;
@@ -163,6 +168,7 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, debugMode: boo
     system_database: `${poolConfig.database}_dbos_sys`,
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     application: configFile.application || undefined,
+    http: configFile.http,
     dbClientMetadata: {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       entities: configFile.dbClientMetadata?.entities,

--- a/src/httpServer/middleware.ts
+++ b/src/httpServer/middleware.ts
@@ -41,12 +41,14 @@ export interface DBOSHttpAuthReturn {
 export interface MiddlewareDefaults extends RegistrationDefaults {
   authMiddleware?: DBOSHttpAuthMiddleware;
   koaBodyParser?: Koa.Middleware;
+  koaCors?: Koa.Middleware;
   koaMiddlewares?: Koa.Middleware[];
 }
 
 export class MiddlewareClassRegistration<CT extends { new(...args: unknown[]): object }> extends ClassRegistration<CT> implements MiddlewareDefaults {
   authMiddleware?: DBOSHttpAuthMiddleware;
   koaBodyParser?: Koa.Middleware;
+  koaCors?: Koa.Middleware;
   koaMiddlewares?: Koa.Middleware[];
 
   constructor(ctor: CT) {
@@ -79,6 +81,17 @@ export function KoaBodyParser(koaBodyParser: Koa.Middleware) {
   function clsdec<T extends { new(...args: unknown[]): object }>(ctor: T) {
     const clsreg = getOrCreateClassRegistration(ctor) as MiddlewareClassRegistration<T>;
     clsreg.koaBodyParser = koaBodyParser;
+  }
+  return clsdec;
+}
+
+/**
+ * Define a Koa CORS policy applied before any middleware. If not set, the default @koa/cors (w/ .yaml config) is used.
+ */
+export function KoaCors(koaCors: Koa.Middleware) {
+  function clsdec<T extends { new(...args: unknown[]): object }>(ctor: T) {
+    const clsreg = getOrCreateClassRegistration(ctor) as MiddlewareClassRegistration<T>;
+    clsreg.koaCors = koaCors;
   }
   return clsdec;
 }

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -52,10 +52,11 @@ export class DBOSHttpServer {
         origin:
           (o: Context)=>{
             const whitelist = dbosExec.config.http?.allowed_origins;
-            if (whitelist) {
-              return (whitelist.includes(o.request.header.origin!) ? o.request.header.origin! : whitelist[0]);
+            const origin = o.request.header.origin ?? '*';
+            if (whitelist && whitelist.length > 0) {
+              return (whitelist.includes(origin) ? origin : whitelist[0]);
             }
-            return o.request.header.origin!;
+            return o.request.header.origin || '*';
           }
       }));
     }

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -1,4 +1,4 @@
-import Koa from 'koa';
+import Koa, { Context } from 'koa';
 import Router from '@koa/router';
 import { bodyParser } from '@koa/bodyparser';
 import cors from "@koa/cors";
@@ -46,7 +46,19 @@ export class DBOSHttpServer {
     this.adminRouter = new Router();
     this.logger = dbosExec.logger;
     this.app = new Koa();
-    this.app.use(cors());
+    if (dbosExec.config.http?.cors_middleware ?? true) {
+      this.app.use(cors({
+        credentials: dbosExec.config.http?.credentials ?? true,
+        origin:
+          (o: Context)=>{
+            const whitelist = dbosExec.config.http?.allowed_origins;
+            if (whitelist) {
+              return (whitelist.includes(o.request.header.origin!) ? o.request.header.origin! : whitelist[0]);
+            }
+            return o.request.header.origin!;
+          }
+      }));
+    }
     this.adminApp = new Koa();
     this.adminApp.use(bodyParser());
     this.adminApp.use(cors());

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -179,7 +179,7 @@ async checkPortAvailability(port: number, host: string): Promise<void> {
                   const whitelist = dbosExec.config.http?.allowed_origins;
                   const origin = o.request.header.origin ?? '*';
                   if (whitelist && whitelist.length > 0) {
-                    return (whitelist.includes(origin) ? origin : whitelist[0]);
+                    return (whitelist.includes(origin) ? origin : '');
                   }
                   return o.request.header.origin || '*';
                 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,7 @@ export {
   // Middleware Decorators
   Authentication,
   KoaBodyParser,
+  KoaCors,
   KoaMiddleware,
 
   // OpenApi Decorators

--- a/tests/httpServer/cors.test.ts
+++ b/tests/httpServer/cors.test.ts
@@ -1,0 +1,255 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import {
+  GetApi,
+} from "../../src";
+import { generateDBOSTestConfig, setUpDBOSTestDb } from "../helpers";
+import request from "supertest";
+import { HandlerContext } from "../../src/httpServer/handler";
+import { KoaCors } from "../../src/httpServer/middleware";
+import { DBOSConfig } from "../../src/dbos-executor";
+import { TestingRuntime, createInternalTestRuntime } from "../../src/testing/testing_runtime";
+import cors from "@koa/cors";
+import { Context } from "koa";
+
+describe("http-cors-tests", () => {
+  let testRuntime: TestingRuntime;
+  let config: DBOSConfig;
+
+  beforeAll(async () => {
+    config = generateDBOSTestConfig();
+    await setUpDBOSTestDb(config);
+  });
+
+  beforeEach(async () => {
+    testRuntime = await createInternalTestRuntime([TestEndpointsDefCORS, TestEndpointsRegCORS, TestEndpointsSpecCORS], config);
+  });
+
+  afterEach(async () => {
+    await testRuntime.destroy();
+  });
+
+  // Check get with us as origin
+  it('should allow requests without credentials from allowed origins', async () => {
+    const response = await request(testRuntime.getHandlersCallback())
+      .get('/hellod') // Default CORS policy
+      .set('Origin', 'https://us.com');
+
+    expect(response.headers['access-control-allow-origin']).toBe('https://us.com');
+    expect(response.status).toBe(200);
+  });
+  it('should allow requests without credentials from allowed origins', async () => {
+    const response = await request(testRuntime.getHandlersCallback())
+      .get('/hellor') // Regular cors() defaults from Koa
+      .set('Origin', 'https://us.com');
+
+    expect(response.headers['access-control-allow-origin']).toBe('*');
+    expect(response.status).toBe(200);
+  });
+  it('should allow requests without credentials from allowed origins', async () => {
+    const response = await request(testRuntime.getHandlersCallback())
+      .get('/hellos') // Custom whitelist cors() implementation
+      .set('Origin', 'https://us.com');
+
+    expect(response.headers['access-control-allow-origin']).toBe('https://us.com');
+    expect(response.status).toBe(200);
+  });
+
+  // Check get with partner as origin
+  it('should allow requests without credentials from allowed origins', async () => {
+    const response = await request(testRuntime.getHandlersCallback())
+      .get('/hellod') // Default CORS policy
+      .set('Origin', 'https://partner.com');
+
+    expect(response.headers['access-control-allow-origin']).toBe('https://partner.com');
+    expect(response.status).toBe(200);
+  });
+  it('should allow requests without credentials from allowed origins', async () => {
+    const response = await request(testRuntime.getHandlersCallback())
+      .get('/hellor') // Regular cors() defaults from Koa
+      .set('Origin', 'https://partner.com');
+
+    expect(response.headers['access-control-allow-origin']).toBe('*');
+    expect(response.status).toBe(200);
+  });
+  it('should allow requests without credentials from allowed origins', async () => {
+    const response = await request(testRuntime.getHandlersCallback())
+      .get('/hellos') // Custom whitelist cors() implementation
+      .set('Origin', 'https://partner.com');
+
+    expect(response.headers['access-control-allow-origin']).toBe('https://partner.com');
+    expect(response.status).toBe(200);
+  });
+
+  // Check get with another origin
+  it('should allow requests without credentials from allowed origins', async () => {
+    const response = await request(testRuntime.getHandlersCallback())
+      .get('/hellod') // Default CORS policy
+      .set('Origin', 'https://crimeware.com');
+
+    expect(response.headers['access-control-allow-origin']).toBe('https://crimeware.com');
+    expect(response.status).toBe(200);
+  });
+  it('should allow requests without credentials from allowed origins', async () => {
+    const response = await request(testRuntime.getHandlersCallback())
+      .get('/hellor') // Regular cors() defaults from Koa
+      .set('Origin', 'https://crimeware.com');
+
+    expect(response.headers['access-control-allow-origin']).toBe('*');
+    expect(response.status).toBe(200);
+  });
+  it('should allow requests without credentials from allowed origins - not this one', async () => {
+    const response = await request(testRuntime.getHandlersCallback())
+      .get('/hellos') // Custom whitelist cors() implementation
+      .set('Origin', 'https://crimeware.com');
+
+    expect(response.headers['access-control-allow-origin']).toBeUndefined();
+    expect(response.status).toBe(200); // IRL this response will not be shared by the browser to the caller; POSTs could be preflighted.
+  });
+
+
+  // Check get with us as origin AND credentials
+  it('should allow requests without credentials from allowed origins', async () => {
+    const response = await request(testRuntime.getHandlersCallback())
+      .get('/hellod') // Default CORS policy
+      .set('Origin', 'https://us.com')
+      .set('Cookie', 'sessionId=abc123');
+
+    expect(response.headers['access-control-allow-origin']).toBe('https://us.com');
+    expect(response.headers['access-control-allow-credentials']).toBe('true');
+
+    expect(response.status).toBe(200);
+  });
+  it('should allow requests without credentials from allowed origins', async () => {
+    const response = await request(testRuntime.getHandlersCallback())
+      .get('/hellor') // Regular cors() defaults from Koa
+      .set('Origin', 'https://us.com')
+      .set('Cookie', 'sessionId=abc123');
+
+    expect(response.headers['access-control-allow-origin']).toBe('*');
+    expect(response.headers['access-control-allow-credentials']).toBeUndefined();
+    // IRL the browser will hate this result of '*' and refuse to share response w/ client
+
+    expect(response.status).toBe(200);
+  });
+  it('should allow requests without credentials from allowed origins', async () => {
+    const response = await request(testRuntime.getHandlersCallback())
+      .get('/hellos') // Custom whitelist cors() implementation
+      .set('Origin', 'https://us.com')
+      .set('Cookie', 'sessionId=abc123');
+
+    expect(response.headers['access-control-allow-origin']).toBe('https://us.com');
+    expect(response.headers['access-control-allow-credentials']).toBe('true');
+
+    expect(response.status).toBe(200);
+  });
+
+  // Check get with partner as origin AND credentials
+  it('should allow requests without credentials from allowed origins', async () => {
+    const response = await request(testRuntime.getHandlersCallback())
+      .get('/hellod') // Default CORS policy
+      .set('Origin', 'https://partner.com')
+      .set('Cookie', 'sessionId=abc123');
+
+    expect(response.headers['access-control-allow-origin']).toBe('https://partner.com');
+    expect(response.headers['access-control-allow-credentials']).toBe('true');
+
+    expect(response.status).toBe(200);
+  });
+  it('should allow requests without credentials from allowed origins', async () => {
+    const response = await request(testRuntime.getHandlersCallback())
+      .get('/hellor') // Regular cors() defaults from Koa
+      .set('Origin', 'https://partner.com')
+      .set('Cookie', 'sessionId=abc123');
+
+    expect(response.headers['access-control-allow-origin']).toBe('*');
+    expect(response.headers['access-control-allow-credentials']).toBeUndefined();
+    // IRL the browser will hate this result of '*' and refuse to share response w/ client
+
+    expect(response.status).toBe(200);
+  });
+  it('should allow requests without credentials from allowed origins', async () => {
+    const response = await request(testRuntime.getHandlersCallback())
+      .get('/hellos') // Custom whitelist cors() implementation
+      .set('Origin', 'https://partner.com')
+      .set('Cookie', 'sessionId=abc123');
+
+    expect(response.headers['access-control-allow-origin']).toBe('https://partner.com');
+    expect(response.headers['access-control-allow-credentials']).toBe('true');
+
+    expect(response.status).toBe(200);
+  });
+
+  // Check get with another origin AND credentials
+  it('should allow requests without credentials from allowed origins', async () => {
+    const response = await request(testRuntime.getHandlersCallback())
+      .get('/hellod') // Default CORS policy
+      .set('Origin', 'https://crimewave.com')
+      .set('Cookie', 'sessionId=abc123');
+
+    expect(response.headers['access-control-allow-origin']).toBe('https://crimewave.com');
+    expect(response.headers['access-control-allow-credentials']).toBe('true');
+
+    expect(response.status).toBe(200);
+  });
+  it('should allow requests without credentials from allowed origins', async () => {
+    const response = await request(testRuntime.getHandlersCallback())
+      .get('/hellor') // Regular cors() defaults from Koa
+      .set('Origin', 'https://crimewave.com')
+      .set('Cookie', 'sessionId=abc123');
+
+    expect(response.headers['access-control-allow-origin']).toBe('*');
+    expect(response.headers['access-control-allow-credentials']).toBeUndefined();
+    // IRL the browser will hate this result of '*' and refuse to share response w/ client
+
+    expect(response.status).toBe(200);
+  });
+  it('should allow requests without credentials from allowed origins - not this one', async () => {
+    const response = await request(testRuntime.getHandlersCallback())
+      .get('/hellos') // Custom whitelist cors() implementation
+      .set('Origin', 'https://crimewave.com')
+      .set('Cookie', 'sessionId=abc123');
+
+    expect(response.headers['access-control-allow-origin']).toBeUndefined();
+    expect(response.headers['access-control-allow-credentials']).toBeUndefined();
+
+    expect(response.status).toBe(200);
+  });
+});
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+class TestEndpointsDefCORS {
+  // eslint-disable-next-line @typescript-eslint/require-await
+  @GetApi("/hellod")
+  static async hello(_ctx: HandlerContext) {
+    return { message: "hello!" };
+  }
+}
+
+@KoaCors(cors())
+class TestEndpointsRegCORS {
+  // eslint-disable-next-line @typescript-eslint/require-await
+  @GetApi("/hellor")
+  static async hello(_ctx: HandlerContext) {
+    return { message: "hello!" };
+  }
+}
+
+@KoaCors(cors({
+  credentials: true,
+  origin:
+    (o: Context)=>{
+      const whitelist = ['https://us.com','https://partner.com'];
+      const origin = o.request.header.origin ?? '*';
+      if (whitelist && whitelist.length > 0) {
+        return (whitelist.includes(origin) ? origin : '');
+      }
+      return o.request.header.origin || '*';
+    }
+}))
+class TestEndpointsSpecCORS {
+  // eslint-disable-next-line @typescript-eslint/require-await
+  @GetApi("/hellos")
+  static async hello(_ctx: HandlerContext) {
+    return { message: "hello!" };
+  }
+}


### PR DESCRIPTION
I9 was trying to deploy a DBOS app with a react frontend.  Calls w/ credentials to DBOS failed for CORS objections.

This PR makes CORS optional (so you could do your own CORS middleware; as it sits the main CORS will prevent anything else from running), based on the config .yaml file.  It also allows credentials by default, if not configured.

Includes a `@KoaCors` decorator that can override CORS policy for the class.  (Sort of like we are doing for body parser).

Once we have this PR settled, documentation will be needed.  That is being drafted now.