### PR TITLE
Fix update notifier

### DIFF
--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -32,7 +32,7 @@ try {
     pkg: packageJson,
     updateCheckInterval: 0
   })
-  if (notifier.update && !notifier.update.current.includes("preview") && !notifier.update.current.includes("placeholder")) {
+  if (notifier.update && !notifier.update.current.includes("preview") && !notifier.update.current.includes("placeholder") && (notifier.update.current !== notifier.update.latest)) {
     console.log(`
   ${chalk.yellow("-----------------------------------------------------------------------------------------")}
 


### PR DESCRIPTION
This PR makes sure we don't print "Update Available" notification when the current version is the same as the latest version.