### PR TITLE
use Symbol.for instead of Symbol ctor

### DIFF
--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -75,9 +75,9 @@ export class DBOSDataType {
   }
 }
 
-const paramMetadataKey = Symbol("dbos:parameter");
-const methodMetadataKey = Symbol("dbos:method");
-const classMetadataKey = Symbol("dbos:class");
+const paramMetadataKey = Symbol.for("dbos:parameter");
+const methodMetadataKey = Symbol.for("dbos:method");
+const classMetadataKey = Symbol.for("dbos:class");
 
 /* Arguments parsing heuristic:
  * - Convert the function to a string


### PR DESCRIPTION
I was debuging Transact using one of our demo apps. Because I was running Transact from the repo against a demo app w/ it's own version of Transact, it couldn't locate any of the handler endpoints. Because I was using two different copies of Transact, I ended up with two different sets of metadata key symbols:

https://github.com/dbos-inc/dbos-transact/blob/6e97e1ec0f80c2a359165a92e6f06e508531848e/src/decorators.ts#L78-L80

This PR switches these symbols from using Symbol's constructor to using [`Symbol.for`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/for). 

```js
Symbol('bar') !== Symbol('bar');
Symbol.for('bar') === Symbol.for('bar');
```
