### PR TITLE
Configurable Environment Variables

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -55,6 +55,7 @@ export interface DBOSConfig {
   readonly userDbclient?: UserDatabaseName;
   readonly telemetry?: TelemetryConfig;
   readonly system_database: string;
+  readonly environmentVariables?: Record<string, string>
   readonly application?: object;
   readonly dbClientMetadata?: any;
   readonly debugProxy?: string;
@@ -143,6 +144,14 @@ export class DBOSExecutor {
   /* WORKFLOW EXECUTOR LIFE CYCLE MANAGEMENT */
   constructor(readonly config: DBOSConfig, systemDatabase?: SystemDatabase) {
     this.debugMode = config.debugProxy ? true : false;
+
+    // Set configured environment variables
+    if (config.environmentVariables) {
+      for (const [key, value] of Object.entries(config.environmentVariables)) {
+        process.env[key] = value;
+      }
+    }
+
     if (config.telemetry?.OTLPExporter) {
       const OTLPExporter = new TelemetryExporter(config.telemetry.OTLPExporter);
       this.telemetryCollector = new TelemetryCollector(OTLPExporter);

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -55,7 +55,7 @@ export interface DBOSConfig {
   readonly userDbclient?: UserDatabaseName;
   readonly telemetry?: TelemetryConfig;
   readonly system_database: string;
-  readonly environmentVariables?: Record<string, string>
+  readonly env?: Record<string, string>
   readonly application?: object;
   readonly dbClientMetadata?: any;
   readonly debugProxy?: string;
@@ -146,8 +146,8 @@ export class DBOSExecutor {
     this.debugMode = config.debugProxy ? true : false;
 
     // Set configured environment variables
-    if (config.environmentVariables) {
-      for (const [key, value] of Object.entries(config.environmentVariables)) {
+    if (config.env) {
+      for (const [key, value] of Object.entries(config.env)) {
         process.env[key] = value;
       }
     }

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -34,7 +34,7 @@ export interface ConfigFile {
   telemetry?: TelemetryConfig;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   application: any;
-  environmentVariables: Record<string, string>;
+  env: Record<string, string>;
   runtimeConfig?: DBOSRuntimeConfig;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   dbClientMetadata?: any;
@@ -169,7 +169,7 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, debugMode: boo
     system_database: `${poolConfig.database}_dbos_sys`,
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     application: configFile.application || undefined,
-    environmentVariables: configFile.environmentVariables || {},
+    env: configFile.env || {},
     http: configFile.http,
     dbClientMetadata: {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -34,6 +34,7 @@ export interface ConfigFile {
   telemetry?: TelemetryConfig;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   application: any;
+  environmentVariables: Record<string, string>;
   runtimeConfig?: DBOSRuntimeConfig;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   dbClientMetadata?: any;
@@ -168,6 +169,7 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, debugMode: boo
     system_database: `${poolConfig.database}_dbos_sys`,
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     application: configFile.application || undefined,
+    environmentVariables: configFile.environmentVariables || {},
     http: configFile.http,
     dbClientMetadata: {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -168,7 +168,7 @@ describe("dbos-config", () => {
           password: \${PGPASSWORD}
           connectionTimeoutMillis: 3000
           app_db_name: 'some DB'
-        environmentVariables:
+        env:
           FOOFOO: barbar
       `;
       jest.restoreAllMocks();

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -159,6 +159,29 @@ describe("dbos-config", () => {
       await dbosExec.telemetryCollector.destroy();
     });
 
+    test("environment variables are set correctly", async () => {
+      const localMockDBOSConfigYamlString = `
+        database:
+          hostname: 'some host'
+          port: 1234
+          username: 'some user'
+          password: \${PGPASSWORD}
+          connectionTimeoutMillis: 3000
+          app_db_name: 'some DB'
+        environmentVariables:
+          FOOFOO: barbar
+      `;
+      jest.restoreAllMocks();
+      jest.spyOn(utils, "readFileSync").mockReturnValue(localMockDBOSConfigYamlString);
+      const [dbosConfig, _dbosRuntimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(mockCLIOptions);
+      const dbosExec = new DBOSExecutor(dbosConfig);
+      expect(process.env.FOOFOO).toBe("barbar")
+      console.log(process.env)
+      // We didn't init, so do some manual cleanup only
+      clearInterval(dbosExec.flushBufferID);
+      await dbosExec.telemetryCollector.destroy();
+    });
+
     test("getConfig throws when it finds a value of different type than the default", async () => {
       const [dbosConfig, _dbosRuntimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(mockCLIOptions);
       const dbosExec = new DBOSExecutor(dbosConfig);


### PR DESCRIPTION
This PR allows you to set environment variables in your `dbos-config.yaml` which are then set in your application before its code is initialized. This is especially useful for setting environment variables in DBOS Cloud.