### PR TITLE
Replay debug without a proxy

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -59,6 +59,7 @@ export interface DBOSConfig {
   readonly application?: object;
   readonly dbClientMetadata?: any;
   readonly debugProxy?: string;
+  readonly debugMode?: boolean;
   readonly http?: {
     readonly cors_middleware?: boolean;
     readonly credentials?: boolean;
@@ -134,6 +135,7 @@ export class DBOSExecutor {
   static readonly defaultNotificationTimeoutSec = 60;
 
   readonly debugMode: boolean;
+  readonly debugProxy: string | undefined;
   static systemDBSchemaName = "dbos";
 
   readonly logger: Logger;
@@ -143,7 +145,8 @@ export class DBOSExecutor {
 
   /* WORKFLOW EXECUTOR LIFE CYCLE MANAGEMENT */
   constructor(readonly config: DBOSConfig, systemDatabase?: SystemDatabase) {
-    this.debugMode = config.debugProxy ? true : false;
+    this.debugMode = config.debugMode ?? false;
+    this.debugProxy = config.debugProxy;
 
     // Set configured environment variables
     if (config.env) {
@@ -162,8 +165,8 @@ export class DBOSExecutor {
     this.logger = new Logger(this.telemetryCollector, this.config.telemetry?.logs);
     this.tracer = new Tracer(this.telemetryCollector);
 
-    if (this.debugMode) {
-      this.logger.info("Running in debug mode!");
+    if (this.debugProxy) {
+      this.logger.info("Running in debug mode with a proxy!");
       try {
         const url = new URL(this.config.debugProxy!);
         this.config.poolConfig.host = url.hostname;

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -165,16 +165,18 @@ export class DBOSExecutor {
     this.logger = new Logger(this.telemetryCollector, this.config.telemetry?.logs);
     this.tracer = new Tracer(this.telemetryCollector);
 
-    if (this.debugProxy) {
-      this.logger.info("Running in debug mode with a proxy!");
-      try {
-        const url = new URL(this.config.debugProxy!);
-        this.config.poolConfig.host = url.hostname;
-        this.config.poolConfig.port = parseInt(url.port, 10);
-        this.logger.info(`Debugging mode proxy: ${this.config.poolConfig.host}:${this.config.poolConfig.port}`);
-      } catch (err) {
-        this.logger.error(err);
-        throw err;
+    if (this.debugMode) {
+      this.logger.info("Running in debug mode!");
+      if (this.debugProxy) {
+        try {
+          const url = new URL(this.config.debugProxy!);
+          this.config.poolConfig.host = url.hostname;
+          this.config.poolConfig.port = parseInt(url.port, 10);
+          this.logger.info(`Debugging mode proxy: ${this.config.poolConfig.host}:${this.config.poolConfig.port}`);
+        } catch (err) {
+          this.logger.error(err);
+          throw err;
+        }
       }
     }
 

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -36,7 +36,6 @@ interface DBOSDebugOptions {
   loglevel?: string,
   configfile?: string,
   entrypoint?: string,
-  direct: boolean,
 }
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -59,16 +58,14 @@ program
 program
   .command('debug')
   .description('Debug a workflow')
-  .option('--direct', 'Run the workflow without a debug proxy')
-  .option('-x, --proxy <string>', 'Specify the time-travel debug proxy URL for debugging cloud traces', 'postgresql://localhost:2345')
+  .option('-x, --proxy <string>', 'Specify the time-travel debug proxy URL for debugging cloud traces')
   .requiredOption('-u, --uuid <string>', 'Specify the workflow UUID to replay')
   .option('-l, --loglevel <string>', 'Specify log level')
   .option('-c, --configfile <string>', 'Specify the config file path', dbosConfigFilePath)
   .option('-e, --entrypoint <string>', 'Specify the entrypoint file path')
   .action(async (options: DBOSDebugOptions) => {
-    const [dbosConfig, runtimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(options, !options.direct);
-    // In direct mode, force proxy to be empty string.
-    await debugWorkflow(dbosConfig, runtimeConfig, options.uuid, options.direct ? undefined : options.proxy);
+    const [dbosConfig, runtimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(options, (options.proxy !== undefined));
+    await debugWorkflow(dbosConfig, runtimeConfig, options.uuid, options.proxy);
   });
 
 program

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -80,7 +80,7 @@ export function writeConfigFile(configFile: ConfigFile, configFilePath: string) 
   }
 }
 
-export function constructPoolConfig(configFile: ConfigFile, debugMode: boolean = false) {
+export function constructPoolConfig(configFile: ConfigFile, useProxy: boolean = false) {
   if (!configFile.database) {
     throw new DBOSInitializationError(`DBOS configuration (dbos-config.yaml) does not contain database config`);
   }
@@ -99,8 +99,8 @@ export function constructPoolConfig(configFile: ConfigFile, debugMode: boolean =
   }
 
   if (!poolConfig.password) {
-    if (debugMode) {
-      poolConfig.password = "DEBUG-MODE"; // Assign a password if not set. We don't need password to authenticate with the local proxy.
+    if (useProxy) {
+      poolConfig.password = "PROXY-MODE"; // Assign a password if not set. We don't need password to authenticate with the local proxy.
     } else {
       const pgPassword: string | undefined = process.env.PGPASSWORD;
       if (pgPassword) {
@@ -129,7 +129,7 @@ export function constructPoolConfig(configFile: ConfigFile, debugMode: boolean =
  * Parse `dbosConfigFilePath` and return DBOSConfig and DBOSRuntimeConfig
  * Considers DBOSCLIStartOptions if provided, which takes precedence over config file
  * */
-export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, debugMode: boolean = false): [DBOSConfig, DBOSRuntimeConfig] {
+export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, useProxy: boolean = false): [DBOSConfig, DBOSRuntimeConfig] {
   const configFilePath = cliOptions?.configfile ?? dbosConfigFilePath;
   const configFile: ConfigFile | undefined = loadConfigFile(configFilePath);
   if (!configFile) {
@@ -142,7 +142,7 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, debugMode: boo
   /* Handle user database config */
   /*******************************/
 
-  const poolConfig = constructPoolConfig(configFile, debugMode)
+  const poolConfig = constructPoolConfig(configFile, useProxy)
 
   /***************************/
   /* Handle telemetry config */

--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -139,7 +139,7 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
 
       if (!this.#dbosExec.debugProxy) {
         // Direct mode skips execution and return the recorded result.
-        return check as R;
+        return (check as RecordedResult<R>).output;
       }
       // If we have a proxy, then execute the user's transaction.
       const result = await txn(tCtxt, ...args);

--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -90,15 +90,17 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
       txn_id: rows[0].txn_id,
     };
 
-    // Send a signal to the debug proxy.
-    await this.#dbosExec.userDatabase.queryWithClient(client, `--proxy:${res.txn_id ?? ''}:${res.txn_snapshot}`);
+    if (this.#dbosExec.debugProxy) {
+      // Send a signal to the debug proxy.
+      await this.#dbosExec.userDatabase.queryWithClient(client, `--proxy:${res.txn_id ?? ''}:${res.txn_snapshot}`);
+    }
 
     return res;
   }
 
   /**
    * Execute a transactional function in debug mode.
-   * It connects to a debug proxy and everything should be read-only.
+   * If a debug proxy is provided, it connects to a debug proxy and everything should be read-only.
    */
   async transaction<T extends any[], R>(txn: Transaction<T, R>, ...args: T): Promise<R> {
     const txnInfo = this.#dbosExec.transactionInfoMap.get(txn.name);
@@ -128,10 +130,18 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
       check = await this.checkExecution<R>(client, funcID);
 
       if (check instanceof Error) {
-        this.logger.warn(`original transaction ${txn.name} failed with error: ${check.message}`);
+        if (this.#dbosExec.debugProxy) {
+          this.logger.warn(`original transaction ${txn.name} failed with error: ${check.message}`);
+        } else {
+          throw check; // In direct mode, directly throw the error.
+        }
       }
 
-      // Execute the user's transaction.
+      if (!this.#dbosExec.debugProxy) {
+        // Direct mode skips execution and return the recorded result.
+        return check as R;
+      }
+      // If we have a proxy, then execute the user's transaction.
       const result = await txn(tCtxt, ...args);
       return result;
     };

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -4,7 +4,7 @@ import { UserDatabaseName } from "../src/user_database";
 import { setApplicationVersion } from "../src/dbos-runtime/applicationVersion";
 
 /* DB management helpers */
-export function generateDBOSTestConfig(dbClient?: UserDatabaseName, debugProxy?: string): DBOSConfig {
+export function generateDBOSTestConfig(dbClient?: UserDatabaseName, debugMode?: boolean, debugProxy?: string): DBOSConfig {
   const dbPassword: string | undefined = process.env.DB_PASSWORD || process.env.PGPASSWORD;
   if (!dbPassword) {
     throw new Error("DB_PASSWORD or PGPASSWORD environment variable not set");
@@ -38,6 +38,7 @@ export function generateDBOSTestConfig(dbClient?: UserDatabaseName, debugProxy?:
       entities: ["KV"],
     },
     debugProxy: debugProxy,
+    debugMode: debugMode,
   };
 
   return dbosTestConfig;

--- a/tests/testing/debug_typeorm.test.ts
+++ b/tests/testing/debug_typeorm.test.ts
@@ -16,7 +16,7 @@ describe("typeorm-debugger-test", () => {
 
   beforeAll(async () => {
     config = generateDBOSTestConfig(UserDatabaseName.TYPEORM);
-    debugConfig = generateDBOSTestConfig(UserDatabaseName.TYPEORM, "http://127.0.0.1:5432");
+    debugConfig = generateDBOSTestConfig(UserDatabaseName.TYPEORM, true);
     await setUpDBOSTestDb(config);
   });
 


### PR DESCRIPTION
This PR removes the requirements for using a debug proxy when replaying a workflow in debug mode.

Without a proxy, we use recorded output/error for transactions instead of stepping through it, so we can support (limited) time travel even with self hosting.

For full database time travel experience, we still need a proxy to connect to DBOS Cloud.