### PR TITLE
Typecast port to Number during configuration setup

### DIFF
--- a/src/dbos-runtime/configure.ts
+++ b/src/dbos-runtime/configure.ts
@@ -16,7 +16,7 @@ export async function configure(host: string | undefined, port: number | undefin
         // Providing a default value
         default: 'localhost',
       },
-    ]) as {host: string};
+    ]) as { host: string };
     host = output.host;
   }
 
@@ -29,8 +29,8 @@ export async function configure(host: string | undefined, port: number | undefin
         // Providing a default value
         default: 5432,
       },
-    ]) as {port: number};
-    port = output.port;
+    ]) as { port: number };
+    port = Number(output.port);
   }
 
   if (!username) {
@@ -42,7 +42,7 @@ export async function configure(host: string | undefined, port: number | undefin
         // Providing a default value
         default: 'postgres',
       },
-    ]) as {username: string};
+    ]) as { username: string };
     username = output.username;
   }
 


### PR DESCRIPTION
Hi,
Port number in string format results in error during deployment.

I was going through the quick start guide to setup the app and when I attempt to deploy the app with `npx dbos-cloud app deploy` it returned an error: 

```
2024-04-14 13:53:35 [info]: Loaded application name from package.json: first-dbos-app
2024-04-14 13:53:35 [info]: Submitting deploy request for first-dbos-app
2024-04-14 13:53:40 [error]: [023805e5-9f3f-4b00-aecb-76dbe741bbfb] Failed to deploy application first-dbos-app: configuring application: 1 error(s) decoding:

* 'database.port' expected type 'int', got unconvertible type 'string', value: '5432'.
```

### Step to reproduce the error
One thing I did differently is I entered the value (5432) manually instead of the letting it pick the default value.
This was during the setup step:
```
npx dbos configure
? What is the hostname of your Postgres server? localhost
? What is the port of your Postgres server? 5432
? What is your Postgres username? postgres
```

### Reference in the codebase
I found the reference of the code and file which is responsible to saving the configurations to `dbos-config.yaml` file here: https://github.com/dbos-inc/dbos-transact/blob/main/src/dbos-runtime/configure.ts#L23 


### Description of how you tested the fix.

**Before the fix:**
```
> const inquirer = require("inquirer");
undefined
> let port;
undefined
>
> while (port !== 'exit') {
...   const output = await inquirer.prompt([
.....     {
.......       type: 'input',
.......       name: 'port',
.......       message: 'What is the port of your Postgres server? (Enter "exit" to quit)',
.......       // Providing a default value
.......       default: 5432,
.......     },
.....   ]);
...
...   port = output.port;
...   console.log(typeof output.port);
... }
? What is the port of your Postgres server? (Enter "exit" to quit) 5432
string
```
**After the fix:**
```
> while (port !== 'exit') {
...   const output = await inquirer.prompt([
.....     {
.......       type: 'input',
.......       name: 'port',
.......       message: 'What is the port of your Postgres server? (Enter "exit" to quit)',
.......       // Providing a default value
.......       default: 5432,
.......     },
.....   ]);
...
...   port = Number(output.port);
...   console.log(typeof port);
... }
? What is the port of your Postgres server? (Enter "exit" to quit) 5432
number
```
I am not sure if this is correct way of testing or even a valid fix in this case, please let me know if I am looking at the wrong direction. Thank you.