### PR TITLE
Eliminate Spurious Warning

### DIFF
--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -168,8 +168,9 @@ function readInterpolatedConfig(configFilePath: string, logger: CLILogger): stri
       logger.debug(`      Substituting value of '${g1}' from process environment.`);
       return process.env[g1] ?? "";
     }
-
-    logger.warn(`      Variable '${g1}' would be substituted from the process environment, but is not defined.`);
+    if (g1 !== "PGPASSWORD") {
+      logger.warn(`      Variable '${g1}' would be substituted from the process environment, but is not defined.`);
+    }
     return "";
   });
 }


### PR DESCRIPTION
Deploy shouldn't warn if `PGPASSWORD` isn't set because DBOS Cloud doesn't use local `PGPASSWORD`.