### PR TITLE
Make cors work with preflight OPTIONS request

### DIFF
--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -181,10 +181,10 @@ async checkPortAvailability(port: number, host: string): Promise<void> {
         const defaults = ro.defaults as MiddlewareDefaults;
         // Check if we need to apply a custom CORS
         if (defaults.koaCors) {
-          router.use(ro.apiURL, defaults.koaCors);
+          router.all(ro.apiURL, defaults.koaCors); // Use router.all to register with all methods including preflight requests
         } else {
           if (dbosExec.config.http?.cors_middleware ?? true) {
-            router.use(ro.apiURL, cors({
+            router.all(ro.apiURL, cors({
               credentials: dbosExec.config.http?.credentials ?? true,
               origin:
                 (o: Context)=>{
@@ -194,7 +194,9 @@ async checkPortAvailability(port: number, host: string): Promise<void> {
                     return (whitelist.includes(origin) ? origin : '');
                   }
                   return o.request.header.origin || '*';
-                }
+                },
+              allowMethods: 'GET,HEAD,PUT,POST,DELETE,PATCH,OPTIONS',
+              allowHeaders: ['Origin', '"X-Requested-With', 'Content-Type', 'Accept', 'Authorization'],
             }));
           }
         }

--- a/tests/httpServer/cors.test.ts
+++ b/tests/httpServer/cors.test.ts
@@ -108,7 +108,7 @@ describe("http-cors-tests", () => {
 
 
   // Check get with us as origin AND credentials
-  it('should allow requests without credentials from allowed origins', async () => {
+  it('should allow requests with credentials from allowed origins', async () => {
     const response = await request(testRuntime.getHandlersCallback())
       .get('/hellod') // Default CORS policy
       .set('Origin', 'https://us.com')
@@ -119,7 +119,7 @@ describe("http-cors-tests", () => {
 
     expect(response.status).toBe(200);
   });
-  it('should allow requests without credentials from allowed origins', async () => {
+  it('should allow requests with credentials from allowed origins', async () => {
     const response = await request(testRuntime.getHandlersCallback())
       .get('/hellor') // Regular cors() defaults from Koa
       .set('Origin', 'https://us.com')
@@ -131,7 +131,7 @@ describe("http-cors-tests", () => {
 
     expect(response.status).toBe(200);
   });
-  it('should allow requests without credentials from allowed origins', async () => {
+  it('should allow requests with credentials from allowed origins', async () => {
     const response = await request(testRuntime.getHandlersCallback())
       .get('/hellos') // Custom whitelist cors() implementation
       .set('Origin', 'https://us.com')
@@ -144,7 +144,7 @@ describe("http-cors-tests", () => {
   });
 
   // Check get with partner as origin AND credentials
-  it('should allow requests without credentials from allowed origins', async () => {
+  it('should allow requests with credentials from allowed origins', async () => {
     const response = await request(testRuntime.getHandlersCallback())
       .get('/hellod') // Default CORS policy
       .set('Origin', 'https://partner.com')
@@ -155,7 +155,7 @@ describe("http-cors-tests", () => {
 
     expect(response.status).toBe(200);
   });
-  it('should allow requests without credentials from allowed origins', async () => {
+  it('should allow requests with credentials from allowed origins', async () => {
     const response = await request(testRuntime.getHandlersCallback())
       .get('/hellor') // Regular cors() defaults from Koa
       .set('Origin', 'https://partner.com')
@@ -167,7 +167,7 @@ describe("http-cors-tests", () => {
 
     expect(response.status).toBe(200);
   });
-  it('should allow requests without credentials from allowed origins', async () => {
+  it('should allow requests with credentials from allowed origins', async () => {
     const response = await request(testRuntime.getHandlersCallback())
       .get('/hellos') // Custom whitelist cors() implementation
       .set('Origin', 'https://partner.com')
@@ -179,8 +179,42 @@ describe("http-cors-tests", () => {
     expect(response.status).toBe(200);
   });
 
+  it('should allow preflight requests with credentials from allowed origins', async () => {
+    const response = await request(testRuntime.getHandlersCallback())
+      .options('/hellos') // Custom whitelist cors() implementation
+      .set('Access-Control-Request-Method', 'GET')
+      .set('Origin', 'https://partner.com')
+      .set('Cookie', 'sessionId=abc123');
+
+    expect(response.status).toBe(204);
+    expect(response.headers['access-control-allow-origin']).toBe('https://partner.com');
+    expect(response.headers['access-control-allow-credentials']).toBe('true');
+  });
+  it('should allow preflight requests with credentials from allowed origins', async () => {
+    const response = await request(testRuntime.getHandlersCallback())
+      .options('/hellor') // Regular cors() defaults from Koa
+      .set('Access-Control-Request-Method', 'GET')
+      .set('Origin', 'https://crimewave.com')
+      .set('Cookie', 'sessionId=abc123');
+
+    expect(response.status).toBe(204);
+    expect(response.headers['access-control-allow-origin']).toBe('*');
+    expect(response.headers['access-control-allow-credentials']).toBeUndefined();
+  });
+  it('should allow preflight requests with credentials from allowed origins', async () => {
+    const response = await request(testRuntime.getHandlersCallback())
+      .options('/hellod') // Default CORS policy
+      .set('Access-Control-Request-Method', 'GET')
+      .set('Origin', 'https://crimewave.com')
+      .set('Cookie', 'sessionId=abc123');
+
+    expect(response.status).toBe(204);
+    expect(response.headers['access-control-allow-origin']).toBe('https://crimewave.com');
+    expect(response.headers['access-control-allow-credentials']).toBe('true');
+  });
+
   // Check get with another origin AND credentials
-  it('should allow requests without credentials from allowed origins', async () => {
+  it('should allow requests with credentials from allowed origins', async () => {
     const response = await request(testRuntime.getHandlersCallback())
       .get('/hellod') // Default CORS policy
       .set('Origin', 'https://crimewave.com')
@@ -191,7 +225,7 @@ describe("http-cors-tests", () => {
 
     expect(response.status).toBe(200);
   });
-  it('should allow requests without credentials from allowed origins', async () => {
+  it('should allow requests with credentials from allowed origins', async () => {
     const response = await request(testRuntime.getHandlersCallback())
       .get('/hellor') // Regular cors() defaults from Koa
       .set('Origin', 'https://crimewave.com')
@@ -203,7 +237,7 @@ describe("http-cors-tests", () => {
 
     expect(response.status).toBe(200);
   });
-  it('should allow requests without credentials from allowed origins - not this one', async () => {
+  it('should allow requests with credentials from allowed origins - not this one', async () => {
     const response = await request(testRuntime.getHandlersCallback())
       .get('/hellos') // Custom whitelist cors() implementation
       .set('Origin', 'https://crimewave.com')
@@ -244,7 +278,8 @@ class TestEndpointsRegCORS {
         return (whitelist.includes(origin) ? origin : '');
       }
       return o.request.header.origin || '*';
-    }
+    },
+  allowMethods: 'GET,OPTIONS', // Need to have options for preflight.
 }))
 class TestEndpointsSpecCORS {
   // eslint-disable-next-line @typescript-eslint/require-await


### PR DESCRIPTION
This PR fixes an issue where CORS policy is not configured for preflight request (`OPTIONS` request from the browser).