### PR TITLE
BYOD Time Travel Option

### DIFF
--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -237,15 +237,15 @@ databaseCommands
   .command('link')
   .description("Link your own Postgres database instance to DBOS Cloud")
   .argument('<name>', 'database instance name')
-  .option('-H, --hostname <string>', 'Specify your database hostname')
-  .option('-p, --port <number>', 'Specify your database port')
+  .requiredOption('-H, --hostname <string>', 'Specify your database hostname')
+  .option('-p, --port <number>', 'Specify your database port', '5432')
   .option('-W, --password <string>', 'Specify password for the dbosadmin user')
-  .option('--timetravel', 'Enable time travel on the linked database')
-  .action((async (dbname: string, options: { hostname: string, port: string, password: string | undefined, timetravel: boolean }) => {
+  .option('--enable-timetravel', 'Enable time travel on the linked database', false)
+  .action((async (dbname: string, options: { hostname: string, port: string, password: string | undefined, enableTimetravel: boolean }) => {
     if (!options.password) {
       options.password = prompt('Database Password: ', { echo: '*' });
     }
-    const exitCode = await linkUserDB(DBOSCloudHost, dbname, options.hostname, Number(options.port), options.password, options.timetravel);
+    const exitCode = await linkUserDB(DBOSCloudHost, dbname, options.hostname, Number(options.port), options.password, options.enableTimetravel);
     process.exit(exitCode);
   }))
 

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -243,7 +243,7 @@ databaseCommands
   .option('--enable-timetravel', 'Enable time travel on the linked database', false)
   .action((async (dbname: string, options: { hostname: string, port: string, password: string | undefined, enableTimetravel: boolean }) => {
     if (!options.password) {
-      options.password = prompt('Database Password: ', { echo: '*' });
+      options.password = prompt('dbosadmin Password: ', { echo: '*' });
     }
     const exitCode = await linkUserDB(DBOSCloudHost, dbname, options.hostname, Number(options.port), options.password, options.enableTimetravel);
     process.exit(exitCode);

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -243,7 +243,7 @@ databaseCommands
   .option('--enable-timetravel', 'Enable time travel on the linked database', false)
   .action((async (dbname: string, options: { hostname: string, port: string, password: string | undefined, enableTimetravel: boolean }) => {
     if (!options.password) {
-      options.password = prompt('dbosadmin Password: ', { echo: '*' });
+      options.password = prompt('Password for the dbosadmin user: ', { echo: '*' });
     }
     const exitCode = await linkUserDB(DBOSCloudHost, dbname, options.hostname, Number(options.port), options.password, options.enableTimetravel);
     process.exit(exitCode);

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -240,11 +240,12 @@ databaseCommands
   .option('-H, --hostname <string>', 'Specify your database hostname')
   .option('-p, --port <number>', 'Specify your database port')
   .option('-W, --password <string>', 'Specify password for the dbosadmin user')
-  .action((async (dbname: string, options: { hostname: string, port: string, password: string | undefined }) => {
+  .option('--timetravel', 'Enable time travel on the linked database')
+  .action((async (dbname: string, options: { hostname: string, port: string, password: string | undefined, timetravel: boolean }) => {
     if (!options.password) {
       options.password = prompt('Database Password: ', { echo: '*' });
     }
-    const exitCode = await linkUserDB(DBOSCloudHost, dbname, options.hostname, Number(options.port), options.password)
+    const exitCode = await linkUserDB(DBOSCloudHost, dbname, options.hostname, Number(options.port), options.password, options.timetravel);
     process.exit(exitCode);
   }))
 

--- a/packages/dbos-cloud/userdb.ts
+++ b/packages/dbos-cloud/userdb.ts
@@ -63,7 +63,7 @@ export async function linkUserDB(host: string, dbName: string, hostName: string,
   try {
     await axios.post(
       `https://${host}/v1alpha1/${userCredentials.userName}/databases/byod`,
-      { Name: dbName, HostName: hostName, Port: port, Password: dbPassword, CaptureProvenance: enableTimetravel},
+      { Name: dbName, HostName: hostName, Port: port, Password: dbPassword, captureProvenance: enableTimetravel },
       {
         headers: {
           "Content-Type": "application/json",

--- a/packages/dbos-cloud/userdb.ts
+++ b/packages/dbos-cloud/userdb.ts
@@ -59,7 +59,7 @@ export async function linkUserDB(host: string, dbName: string, hostName: string,
   const logger = getLogger();
   const userCredentials = getCloudCredentials();
   const bearerToken = "Bearer " + userCredentials.token;
-
+  logger.info(`Linking Postgres instance: ${dbName}, hostname: ${hostName}, port: ${port}, time travel: ${enableTimetravel}`);
   try {
     await axios.post(
       `https://${host}/v1alpha1/${userCredentials.userName}/databases/byod`,

--- a/packages/dbos-cloud/userdb.ts
+++ b/packages/dbos-cloud/userdb.ts
@@ -55,7 +55,7 @@ export async function createUserDb(host: string, dbName: string, appDBUsername: 
   }
 }
 
-export async function linkUserDB(host: string, dbName: string, hostName: string, port: number, dbPassword: string) {
+export async function linkUserDB(host: string, dbName: string, hostName: string, port: number, dbPassword: string, enableTimetravel: boolean) {
   const logger = getLogger();
   const userCredentials = getCloudCredentials();
   const bearerToken = "Bearer " + userCredentials.token;
@@ -63,7 +63,7 @@ export async function linkUserDB(host: string, dbName: string, hostName: string,
   try {
     await axios.post(
       `https://${host}/v1alpha1/${userCredentials.userName}/databases/byod`,
-      { Name: dbName, HostName: hostName, Port: port, Password: dbPassword },
+      { Name: dbName, HostName: hostName, Port: port, Password: dbPassword, CaptureProvenance: enableTimetravel},
       {
         headers: {
           "Content-Type": "application/json",

--- a/packages/dbos-cloud/userdb.ts
+++ b/packages/dbos-cloud/userdb.ts
@@ -59,7 +59,7 @@ export async function linkUserDB(host: string, dbName: string, hostName: string,
   const logger = getLogger();
   const userCredentials = getCloudCredentials();
   const bearerToken = "Bearer " + userCredentials.token;
-  logger.info(`Linking Postgres instance: ${dbName}, hostname: ${hostName}, port: ${port}, time travel: ${enableTimetravel}`);
+  logger.info(`Linking Postgres instance ${dbName} to DBOS Cloud. Hostname: ${hostName} Port: ${port} Time travel: ${enableTimetravel}`);
   try {
     await axios.post(
       `https://${host}/v1alpha1/${userCredentials.userName}/databases/byod`,


### PR DESCRIPTION
Add a new option `--enable-timetravel` to the link DB command. If this option is set, we set up database time travel infra on DBOS Cloud for the linked Postgres.