### PR TITLE
register many entrypoints

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
         ports:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
-  
+
     steps:
       - name: "Setup postgres config"
         run: |

--- a/dbos-config.schema.json
+++ b/dbos-config.schema.json
@@ -109,9 +109,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "entrypoint": {
-          "type": "string"
-        },
         "entrypoints": {
           "type": "array",
           "items": {

--- a/dbos-config.schema.json
+++ b/dbos-config.schema.json
@@ -112,6 +112,12 @@
         "entrypoint": {
           "type": "string"
         },
+        "entrypoints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "port": {
           "type": "number"
         }

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -35,7 +35,8 @@ interface DBOSDebugOptions {
   proxy: string,
   loglevel?: string,
   configfile?: string,
-  entrypoint?: string,
+  entrypoint?: string, // DEPRECATED
+  entrypoints?: string[],
 }
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -48,7 +49,8 @@ program
   .option('-p, --port <number>', 'Specify the port number')
   .option('-l, --loglevel <string>', 'Specify log level')
   .option('-c, --configfile <string>', 'Specify the config file path', dbosConfigFilePath)
-  .option('-e, --entrypoint <string>', 'Specify the entrypoint file path')
+  .option('-e, --entrypoint <string>', 'Specify the entrypoint file path [DEPRECATED]')
+  .option('-E, --entrypoints <string...>', 'Specify the entrypoints file paths')
   .action(async (options: DBOSCLIStartOptions) => {
     const [dbosConfig, runtimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(options);
     const runtime = new DBOSRuntime(dbosConfig, runtimeConfig);
@@ -62,7 +64,8 @@ program
   .requiredOption('-u, --uuid <string>', 'Specify the workflow UUID to replay')
   .option('-l, --loglevel <string>', 'Specify log level')
   .option('-c, --configfile <string>', 'Specify the config file path', dbosConfigFilePath)
-  .option('-e, --entrypoint <string>', 'Specify the entrypoint file path')
+  .option('-e, --entrypoint <string>', 'Specify the entrypoint file path [DEPRECATED]')
+  .option('-E, --entrypoints <string...>', 'Specify the entrypoints file paths')
   .action(async (options: DBOSDebugOptions) => {
     const [dbosConfig, runtimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(options, (options.proxy !== undefined));
     await debugWorkflow(dbosConfig, runtimeConfig, options.uuid, options.proxy);

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -17,41 +17,34 @@ const program = new Command();
 ////////////////////////
 
 export interface DBOSCLIStartOptions {
-  port?: number,
-  loglevel?: string,
-  configfile?: string,
-  entrypoint?: string, // DEPRECATED
-  entrypoints?: string[],
+  port?: number;
+  loglevel?: string;
+  configfile?: string;
 }
 
 export interface DBOSConfigureOptions {
-  host?: string,
-  port?: number,
-  username?: string,
+  host?: string;
+  port?: number;
+  username?: string;
 }
 
-
 interface DBOSDebugOptions {
-  uuid: string, // Workflow UUID
-  proxy: string,
-  loglevel?: string,
-  configfile?: string,
-  entrypoint?: string, // DEPRECATED
-  entrypoints?: string[],
+  uuid: string; // Workflow UUID
+  proxy: string;
+  loglevel?: string;
+  configfile?: string;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const packageJson = require('../../../package.json') as { version: string };
+const packageJson = require("../../../package.json") as { version: string };
 program.version(packageJson.version);
 
 program
-  .command('start')
-  .description('Start the server')
-  .option('-p, --port <number>', 'Specify the port number')
-  .option('-l, --loglevel <string>', 'Specify log level')
-  .option('-c, --configfile <string>', 'Specify the config file path', dbosConfigFilePath)
-  .option('-e, --entrypoint <string>', 'Specify the entrypoint file path [DEPRECATED]')
-  .option('-E, --entrypoints <string...>', 'Specify the entrypoints file paths')
+  .command("start")
+  .description("Start the server")
+  .option("-p, --port <number>", "Specify the port number")
+  .option("-l, --loglevel <string>", "Specify log level")
+  .option("-c, --configfile <string>", "Specify the config file path", dbosConfigFilePath)
   .action(async (options: DBOSCLIStartOptions) => {
     const [dbosConfig, runtimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(options);
     const runtime = new DBOSRuntime(dbosConfig, runtimeConfig);
@@ -59,16 +52,14 @@ program
   });
 
 program
-  .command('debug')
-  .description('Debug a workflow')
-  .option('-x, --proxy <string>', 'Specify the time-travel debug proxy URL for debugging cloud traces')
-  .requiredOption('-u, --uuid <string>', 'Specify the workflow UUID to replay')
-  .option('-l, --loglevel <string>', 'Specify log level')
-  .option('-c, --configfile <string>', 'Specify the config file path', dbosConfigFilePath)
-  .option('-e, --entrypoint <string>', 'Specify the entrypoint file path [DEPRECATED]')
-  .option('-E, --entrypoints <string...>', 'Specify the entrypoints file paths')
+  .command("debug")
+  .description("Debug a workflow")
+  .option("-x, --proxy <string>", "Specify the time-travel debug proxy URL for debugging cloud traces")
+  .requiredOption("-u, --uuid <string>", "Specify the workflow UUID to replay")
+  .option("-l, --loglevel <string>", "Specify log level")
+  .option("-c, --configfile <string>", "Specify the config file path", dbosConfigFilePath)
   .action(async (options: DBOSDebugOptions) => {
-    const [dbosConfig, runtimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(options, (options.proxy !== undefined));
+    const [dbosConfig, runtimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(options, options.proxy !== undefined);
     await debugWorkflow(dbosConfig, runtimeConfig, options.uuid, options.proxy);
   });
 
@@ -79,7 +70,6 @@ program
   .action((_options: { appName: string }) => {
     console.log("NOTE: This command has been removed in favor of `npx @dbos-inc/create` or `npm create @dbos-inc`");
   });
-
 
 program
   .command('configure')

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -20,7 +20,8 @@ export interface DBOSCLIStartOptions {
   port?: number,
   loglevel?: string,
   configfile?: string,
-  entrypoint?: string,
+  entrypoint?: string, // DEPRECATED
+  entrypoints?: string[],
 }
 
 export interface DBOSConfigureOptions {

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -184,9 +184,7 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, useProxy: bool
   const entrypoints = new Set<string>();
   // CLI overrides configuration
   if (configFile.runtimeConfig?.entrypoints) {
-    if (configFile.runtimeConfig.entrypoints) {
-      configFile.runtimeConfig.entrypoints.forEach((entry) => entrypoints.add(entry));
-    }
+    configFile.runtimeConfig.entrypoints.forEach((entry) => entrypoints.add(entry));
   } else {
     entrypoints.add(defaultEntryPoint);
   }

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -185,9 +185,13 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, useProxy: bool
   // CLI overrides configuration
   if (cliOptions?.entrypoint) {
     entrypoints.push(cliOptions.entrypoint);
-  } else if (configFile.runtimeConfig?.entrypoints) {
+  } else if (configFile.runtimeConfig?.entrypoints || configFile.runtimeConfig?.entrypoint) {
     // Take care of duplicates, if any
     entrypoints.push(...new Set(configFile.runtimeConfig?.entrypoints));
+    // Support for deprecated `entrypoint` property
+    if (configFile.runtimeConfig?.entrypoint) {
+      entrypoints.push(configFile.runtimeConfig.entrypoint);
+    }
   } else {
     entrypoints.push(defaultEntryPoint)
   }

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -118,12 +118,12 @@ export function constructPoolConfig(configFile: ConfigFile, useProxy: boolean = 
     poolConfig.ssl = { ca: [readFileSync(configFile.database.ssl_ca)], rejectUnauthorized: true };
   } else if (poolConfig.host != "localhost" && poolConfig.host != "127.0.0.1") {
     // Otherwise, connect to Postgres using TLS but do not verify the server certificate. (equivalent to require)
-    poolConfig.ssl = { rejectUnauthorized: false }
+    poolConfig.ssl = { rejectUnauthorized: false };
   } else {
     // For local development only, do not use TLS (to support Dockerized Postgres, which does not support SSL connections)
-    poolConfig.ssl = false
+    poolConfig.ssl = false;
   }
-  return poolConfig
+  return poolConfig;
 }
 
 /*
@@ -143,7 +143,7 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, useProxy: bool
   /* Handle user database config */
   /*******************************/
 
-  const poolConfig = constructPoolConfig(configFile, useProxy)
+  const poolConfig = constructPoolConfig(configFile, useProxy);
 
   /***************************/
   /* Handle telemetry config */
@@ -181,8 +181,9 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, useProxy: bool
   /*************************************/
   /* Build final runtime Configuration */
   /*************************************/
+  const defaultEntrypoint = cliOptions?.entrypoint || "dist/operations.js";
   const runtimeConfig: DBOSRuntimeConfig = {
-    entrypoint: cliOptions?.entrypoint || configFile.runtimeConfig?.entrypoint || "dist/operations.js",
+    entrypoints: Array.from(new Set(configFile.runtimeConfig?.entrypoints?.concat(defaultEntrypoint))) || [defaultEntrypoint],
     port: Number(cliOptions?.port) || Number(configFile.runtimeConfig?.port) || 3000,
   };
 

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -193,7 +193,7 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, useProxy: bool
       entrypoints.push(configFile.runtimeConfig.entrypoint);
     }
   } else {
-    entrypoints.push(defaultEntryPoint)
+    entrypoints.push(defaultEntryPoint);
   }
   const runtimeConfig: DBOSRuntimeConfig = {
     entrypoints,

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -191,7 +191,6 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, useProxy: bool
       entrypoints.add(cliOptions.entrypoint)
     }
   } else if (configFile.runtimeConfig?.entrypoints || configFile.runtimeConfig?.entrypoint) {
-    // Take care of duplicates, if any
     if (configFile.runtimeConfig.entrypoints) {
       configFile.runtimeConfig.entrypoints.forEach(entry => entrypoints.add(entry));
     }

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -191,9 +191,6 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, useProxy: bool
   } else {
     entrypoints.push('dist/operations.ts')
   }
-  console.log(cliOptions);
-  console.log(configFile.runtimeConfig?.entrypoints);
-  console.log(entrypoints);
   const runtimeConfig: DBOSRuntimeConfig = {
     entrypoints,
     port: Number(cliOptions?.port) || Number(configFile.runtimeConfig?.port) || 3000,

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -42,14 +42,14 @@ export interface ConfigFile {
 }
 
 /*
-* Substitute environment variables using a regex for matching.
-* Will find anything in curly braces.
-* TODO: Use a more robust solution.
-*/
+ * Substitute environment variables using a regex for matching.
+ * Will find anything in curly braces.
+ * TODO: Use a more robust solution.
+ */
 export function substituteEnvVars(content: string): string {
-  const regex = /\${([^}]+)}/g;  // Regex to match ${VAR_NAME} style placeholders
+  const regex = /\${([^}]+)}/g; // Regex to match ${VAR_NAME} style placeholders
   return content.replace(regex, (_, g1: string) => {
-    return process.env[g1] || "";  // If the env variable is not set, return an empty string.
+    return process.env[g1] || ""; // If the env variable is not set, return an empty string.
   });
 }
 
@@ -183,19 +183,9 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, useProxy: bool
   /*************************************/
   const entrypoints = new Set<string>();
   // CLI overrides configuration
-  if (cliOptions?.entrypoints || cliOptions?.entrypoint) {
-    if (cliOptions.entrypoints) {
-      cliOptions.entrypoints.forEach(entry => entrypoints.add(entry));
-    }
-    if (cliOptions.entrypoint) {
-      entrypoints.add(cliOptions.entrypoint)
-    }
-  } else if (configFile.runtimeConfig?.entrypoints || configFile.runtimeConfig?.entrypoint) {
+  if (configFile.runtimeConfig?.entrypoints) {
     if (configFile.runtimeConfig.entrypoints) {
-      configFile.runtimeConfig.entrypoints.forEach(entry => entrypoints.add(entry));
-    }
-    if (configFile.runtimeConfig.entrypoint) {
-      entrypoints.add(configFile.runtimeConfig.entrypoint);
+      configFile.runtimeConfig.entrypoints.forEach((entry) => entrypoints.add(entry));
     }
   } else {
     entrypoints.add(defaultEntryPoint);

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "../utils";
 import { DBOSConfig } from "../dbos-executor";
 import { PoolConfig } from "pg";
 import YAML from "yaml";
-import { DBOSRuntimeConfig } from "./runtime";
+import { DBOSRuntimeConfig, defaultEntryPoint } from "./runtime";
 import { UserDatabaseName } from "../user_database";
 import { DBOSCLIStartOptions } from "./cli";
 import { TelemetryConfig } from "../telemetry";
@@ -189,7 +189,7 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, useProxy: bool
     // Take care of duplicates, if any
     entrypoints.push(...new Set(configFile.runtimeConfig?.entrypoints));
   } else {
-    entrypoints.push('dist/operations.ts')
+    entrypoints.push(defaultEntryPoint)
   }
   const runtimeConfig: DBOSRuntimeConfig = {
     entrypoints,

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -181,9 +181,21 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, useProxy: bool
   /*************************************/
   /* Build final runtime Configuration */
   /*************************************/
-  const defaultEntrypoint = cliOptions?.entrypoint || "dist/operations.js";
+  const entrypoints: string[] = []
+  // CLI overrides configuration
+  if (cliOptions?.entrypoint) {
+    entrypoints.push(cliOptions.entrypoint);
+  } else if (configFile.runtimeConfig?.entrypoints) {
+    // Take care of duplicates, if any
+    entrypoints.push(...new Set(configFile.runtimeConfig?.entrypoints));
+  } else {
+    entrypoints.push('dist/operations.ts')
+  }
+  console.log(cliOptions);
+  console.log(configFile.runtimeConfig?.entrypoints);
+  console.log(entrypoints);
   const runtimeConfig: DBOSRuntimeConfig = {
-    entrypoints: Array.from(new Set(configFile.runtimeConfig?.entrypoints?.concat(defaultEntrypoint))) || [defaultEntrypoint],
+    entrypoints,
     port: Number(cliOptions?.port) || Number(configFile.runtimeConfig?.port) || 3000,
   };
 

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -181,22 +181,28 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, useProxy: bool
   /*************************************/
   /* Build final runtime Configuration */
   /*************************************/
-  const entrypoints: string[] = []
+  const entrypoints = new Set<string>();
   // CLI overrides configuration
-  if (cliOptions?.entrypoint) {
-    entrypoints.push(cliOptions.entrypoint);
+  if (cliOptions?.entrypoints || cliOptions?.entrypoint) {
+    if (cliOptions.entrypoints) {
+      cliOptions.entrypoints.forEach(entry => entrypoints.add(entry));
+    }
+    if (cliOptions.entrypoint) {
+      entrypoints.add(cliOptions.entrypoint)
+    }
   } else if (configFile.runtimeConfig?.entrypoints || configFile.runtimeConfig?.entrypoint) {
     // Take care of duplicates, if any
-    entrypoints.push(...new Set(configFile.runtimeConfig?.entrypoints));
-    // Support for deprecated `entrypoint` property
-    if (configFile.runtimeConfig?.entrypoint) {
-      entrypoints.push(configFile.runtimeConfig.entrypoint);
+    if (configFile.runtimeConfig.entrypoints) {
+      configFile.runtimeConfig.entrypoints.forEach(entry => entrypoints.add(entry));
+    }
+    if (configFile.runtimeConfig.entrypoint) {
+      entrypoints.add(configFile.runtimeConfig.entrypoint);
     }
   } else {
-    entrypoints.push(defaultEntryPoint);
+    entrypoints.add(defaultEntryPoint);
   }
   const runtimeConfig: DBOSRuntimeConfig = {
-    entrypoints,
+    entrypoints: [...entrypoints],
     port: Number(cliOptions?.port) || Number(configFile.runtimeConfig?.port) || 3000,
   };
 

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -182,7 +182,6 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, useProxy: bool
   /* Build final runtime Configuration */
   /*************************************/
   const entrypoints = new Set<string>();
-  // CLI overrides configuration
   if (configFile.runtimeConfig?.entrypoints) {
     configFile.runtimeConfig.entrypoints.forEach((entry) => entrypoints.add(entry));
   } else {

--- a/src/dbos-runtime/debug.ts
+++ b/src/dbos-runtime/debug.ts
@@ -8,12 +8,8 @@ export async function debugWorkflow(dbosConfig: DBOSConfig, runtimeConfig: DBOSR
   const logger = new GlobalLogger();
   try {
     const dbosExec = new DBOSExecutor(dbosConfig);
-    const entrypoints = runtimeConfig.entrypoints;
-    const classes = await Promise.all(
-      entrypoints.map(async (entrypoint) => {
-        return await DBOSRuntime.loadClasses(entrypoint);
-      })
-    );
+    dbosExec.logger.debug(`Loading classes from entrypoints ${runtimeConfig.entrypoints}`);
+    const classes = await DBOSRuntime.loadClasses(runtimeConfig.entrypoints);
     await dbosExec.init(...classes);
 
     // Invoke the workflow in debug mode.

--- a/src/dbos-runtime/debug.ts
+++ b/src/dbos-runtime/debug.ts
@@ -8,7 +8,7 @@ export async function debugWorkflow(dbosConfig: DBOSConfig, runtimeConfig: DBOSR
   const logger = new GlobalLogger();
   try {
     const dbosExec = new DBOSExecutor(dbosConfig);
-    dbosExec.logger.debug(`Loading classes from entrypoints ${runtimeConfig.entrypoints}`);
+    dbosExec.logger.debug(`Loading classes from entrypoints: ${JSON.stringify(runtimeConfig.entrypoints)}`);
     const classes = await DBOSRuntime.loadClasses(runtimeConfig.entrypoints);
     await dbosExec.init(...classes);
 

--- a/src/dbos-runtime/runtime.ts
+++ b/src/dbos-runtime/runtime.ts
@@ -14,6 +14,7 @@ interface ModuleExports {
 }
 
 export interface DBOSRuntimeConfig {
+  entrypoint?: string; // DEPRECATED
   entrypoints: string[];
   port: number;
 }

--- a/src/dbos-runtime/runtime.ts
+++ b/src/dbos-runtime/runtime.ts
@@ -37,7 +37,7 @@ export class DBOSRuntime {
   async initAndStart() {
     try {
       this.dbosExec = new DBOSExecutor(this.dbosConfig);
-      this.dbosExec.logger.debug(`Loading classes from entrypoints ${this.runtimeConfig.entrypoints}`);
+      this.dbosExec.logger.debug(`Loading classes from entrypoints ${JSON.stringify(this.runtimeConfig.entrypoints)}`);
       const classes = await DBOSRuntime.loadClasses(this.runtimeConfig.entrypoints);
       await this.dbosExec.init(...classes);
       const server = new DBOSHttpServer(this.dbosExec);

--- a/src/dbos-runtime/runtime.ts
+++ b/src/dbos-runtime/runtime.ts
@@ -17,6 +17,7 @@ export interface DBOSRuntimeConfig {
   entrypoints: string[];
   port: number;
 }
+export const defaultEntryPoint = "dist/operations.js";
 
 export class DBOSRuntime {
   private dbosConfig: DBOSConfig;

--- a/src/dbos-runtime/runtime.ts
+++ b/src/dbos-runtime/runtime.ts
@@ -14,7 +14,6 @@ interface ModuleExports {
 }
 
 export interface DBOSRuntimeConfig {
-  entrypoint?: string; // DEPRECATED
   entrypoints: string[];
   port: number;
 }

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -70,13 +70,14 @@ describe("dbos-config", () => {
       expect(runtimeConfig.entrypoints[0]).toBe(defaultEntryPoint);
     });
 
-    test("runtime config contains default entrypoint if none provided", () => {
+    test("runtime config correctly parses entrypoints", () => {
       const mockDBOSConfigWithEntryPoints = mockDBOSConfigYamlString + `\n
       runtimeConfig:
         port: 1234
         entrypoints:
           - a
           - b
+        entrypoint: c
       `;
       jest.spyOn(utils, "readFileSync").mockReturnValue(mockDBOSConfigWithEntryPoints);
 
@@ -86,9 +87,10 @@ describe("dbos-config", () => {
       expect(runtimeConfig?.port).toBe(1234);
       expect(runtimeConfig.entrypoints).toBeDefined();
       expect(runtimeConfig.entrypoints).toBeInstanceOf(Array);
-      expect(runtimeConfig.entrypoints).toHaveLength(2);
+      expect(runtimeConfig.entrypoints).toHaveLength(3);
       expect(runtimeConfig.entrypoints[0]).toBe("a");
       expect(runtimeConfig.entrypoints[1]).toBe("b");
+      expect(runtimeConfig.entrypoints[2]).toBe("c");
     })
 
     test("fails to read config file", () => {

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -71,14 +71,15 @@ describe("dbos-config", () => {
     });
 
     test("runtime config correctly parses entrypoints", () => {
-      const mockDBOSConfigWithEntryPoints = mockDBOSConfigYamlString + `\n
+      const mockDBOSConfigWithEntryPoints =
+        mockDBOSConfigYamlString +
+        `\n
       runtimeConfig:
         port: 1234
         entrypoints:
           - a
           - b
           - b
-        entrypoint: c
       `;
       jest.spyOn(utils, "readFileSync").mockReturnValue(mockDBOSConfigWithEntryPoints);
 
@@ -88,11 +89,10 @@ describe("dbos-config", () => {
       expect(runtimeConfig?.port).toBe(1234);
       expect(runtimeConfig.entrypoints).toBeDefined();
       expect(runtimeConfig.entrypoints).toBeInstanceOf(Array);
-      expect(runtimeConfig.entrypoints).toHaveLength(3);
+      expect(runtimeConfig.entrypoints).toHaveLength(2);
       expect(runtimeConfig.entrypoints[0]).toBe("a");
       expect(runtimeConfig.entrypoints[1]).toBe("b");
-      expect(runtimeConfig.entrypoints[2]).toBe("c");
-    })
+    });
 
     test("fails to read config file", () => {
       jest.spyOn(utils, "readFileSync").mockImplementation(() => {

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -77,6 +77,7 @@ describe("dbos-config", () => {
         entrypoints:
           - a
           - b
+          - b
         entrypoint: c
       `;
       jest.spyOn(utils, "readFileSync").mockReturnValue(mockDBOSConfigWithEntryPoints);

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -74,8 +74,8 @@ describe("dbos-config", () => {
       expect(runtimeConfig.entrypoints).toBeDefined();
       expect(runtimeConfig.entrypoints).toBeInstanceOf(Array);
       expect(runtimeConfig.entrypoints).toHaveLength(2);
-      expect(runtimeConfig.entrypoints[0]).toBe("a.js");
-      expect(runtimeConfig.entrypoints[1]).toBe("b.js");
+      expect(runtimeConfig.entrypoints[0]).toBe("a");
+      expect(runtimeConfig.entrypoints[1]).toBe("b");
     });
 
     test("fails to read config file", () => {

--- a/tests/dbos-runtime/runtime.test.ts
+++ b/tests/dbos-runtime/runtime.test.ts
@@ -37,9 +37,9 @@ async function waitForMessageTest(command: ChildProcess, port: string) {
       const response = await axios.get(`http://127.0.0.1:${port}/greeting/dbos`);
       expect(response.status).toBe(200);
     } catch (error) {
-      console.error("Error sending test request")
-      console.error(`status: ${(error as AxiosError).response?.status}`);
-      console.error(`statusText: ${(error as AxiosError).response?.statusText}`);
+      const errMsg =
+        `Error sending test request: status: ${(error as AxiosError).response?.status}, statusText: ${(error as AxiosError).response?.statusText}`;
+      console.error(errMsg)
       throw error;
     }
   } finally {

--- a/tests/dbos-runtime/runtime.test.ts
+++ b/tests/dbos-runtime/runtime.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 import { spawn, execSync, ChildProcess } from "child_process";
 import { Writable } from "stream";
 import { Client } from "pg";
@@ -37,7 +37,9 @@ async function waitForMessageTest(command: ChildProcess, port: string) {
       const response = await axios.get(`http://127.0.0.1:${port}/greeting/dbos`);
       expect(response.status).toBe(200);
     } catch (error) {
-      console.error(error);
+      console.error("Error sending test request")
+      console.error(`status: ${(error as AxiosError).response?.status}`);
+      console.error(`statusText: ${(error as AxiosError).response?.statusText}`);
       throw error;
     }
   } finally {
@@ -105,7 +107,8 @@ database:
   connectionTimeoutMillis: 3000
   app_db_client: 'knex'
 runtimeConfig:
-  entrypoint: dist/entrypoint.js
+  entrypoints:
+    - dist/entrypoint.js
 `;
     const filePath = "dbos-config.yaml";
     fs.copyFileSync(filePath, `${filePath}.bak`);

--- a/tests/dbos-runtime/runtime.test.ts
+++ b/tests/dbos-runtime/runtime.test.ts
@@ -89,15 +89,15 @@ describe("runtime-entrypoint-tests", () => {
     process.chdir("../../../..");
   });
 
-  test("runtime-hello using deprecated entrypoint CLI option", async () => {
-    const command = spawn("node_modules/@dbos-inc/dbos-sdk/dist/src/dbos-runtime/cli.js", ["start", "--port", "1234", "--entrypoint", "dist/entrypoint.js"], {
+  test("runtime-hello using entrypoints CLI option", async () => {
+    const command = spawn("node_modules/@dbos-inc/dbos-sdk/dist/src/dbos-runtime/cli.js", ["start", "--port", "1234", "-E", "dist/entrypoint.js"], {
       env: process.env,
     });
     await waitForMessageTest(command, "1234");
   });
 
-  test("runtime-hello using entrypoints CLI option", async () => {
-    const command = spawn("node_modules/@dbos-inc/dbos-sdk/dist/src/dbos-runtime/cli.js", ["start", "--port", "1234", "-E", "dist/entrypoint.js"], {
+  test("runtime-hello using deprecated entrypoint CLI option", async () => {
+    const command = spawn("node_modules/@dbos-inc/dbos-sdk/dist/src/dbos-runtime/cli.js", ["start", "--port", "1234", "-e", "dist/entrypoint.js"], {
       env: process.env,
     });
     await waitForMessageTest(command, "1234");

--- a/tests/dbos-runtime/runtime.test.ts
+++ b/tests/dbos-runtime/runtime.test.ts
@@ -89,8 +89,15 @@ describe("runtime-entrypoint-tests", () => {
     process.chdir("../../../..");
   });
 
-  test("runtime-hello using entrypoint CLI option", async () => {
+  test("runtime-hello using deprecated entrypoint CLI option", async () => {
     const command = spawn("node_modules/@dbos-inc/dbos-sdk/dist/src/dbos-runtime/cli.js", ["start", "--port", "1234", "--entrypoint", "dist/entrypoint.js"], {
+      env: process.env,
+    });
+    await waitForMessageTest(command, "1234");
+  });
+
+  test("runtime-hello using entrypoints CLI option", async () => {
+    const command = spawn("node_modules/@dbos-inc/dbos-sdk/dist/src/dbos-runtime/cli.js", ["start", "--port", "1234", "-E", "dist/entrypoint.js"], {
       env: process.env,
     });
     await waitForMessageTest(command, "1234");

--- a/tests/dbos-runtime/runtime.test.ts
+++ b/tests/dbos-runtime/runtime.test.ts
@@ -67,7 +67,7 @@ async function dropHelloSystemDB() {
 }
 
 function configureHelloExample() {
-  execSync("npm i");
+  execSync("npm ci");
   execSync("npm run build");
   if (process.env.PGPASSWORD === undefined) {
     process.env.PGPASSWORD = "dbos";

--- a/tests/dbos-runtime/runtime.test.ts
+++ b/tests/dbos-runtime/runtime.test.ts
@@ -90,14 +90,14 @@ describe("runtime-entrypoint-tests", () => {
   });
 
   test("runtime-hello using entrypoints CLI option", async () => {
-    const command = spawn("node_modules/@dbos-inc/dbos-sdk/dist/src/dbos-runtime/cli.js", ["start", "--port", "1234", "-E", "dist/entrypoint.js"], {
+    const command = spawn("node_modules/@dbos-inc/dbos-sdk/dist/src/dbos-runtime/cli.js", ["start", "--port", "1234", "--entrypoints", "dist/entrypoint.js"], {
       env: process.env,
     });
     await waitForMessageTest(command, "1234");
   });
 
   test("runtime-hello using deprecated entrypoint CLI option", async () => {
-    const command = spawn("node_modules/@dbos-inc/dbos-sdk/dist/src/dbos-runtime/cli.js", ["start", "--port", "1234", "-e", "dist/entrypoint.js"], {
+    const command = spawn("node_modules/@dbos-inc/dbos-sdk/dist/src/dbos-runtime/cli.js", ["start", "--port", "1234", "--entrypoint", "dist/entrypoint.js"], {
       env: process.env,
     });
     await waitForMessageTest(command, "1234");

--- a/tests/dbos-runtime/runtime.test.ts
+++ b/tests/dbos-runtime/runtime.test.ts
@@ -37,9 +37,8 @@ async function waitForMessageTest(command: ChildProcess, port: string) {
       const response = await axios.get(`http://127.0.0.1:${port}/greeting/dbos`);
       expect(response.status).toBe(200);
     } catch (error) {
-      const errMsg =
-        `Error sending test request: status: ${(error as AxiosError).response?.status}, statusText: ${(error as AxiosError).response?.statusText}`;
-      console.error(errMsg)
+      const errMsg = `Error sending test request: status: ${(error as AxiosError).response?.status}, statusText: ${(error as AxiosError).response?.statusText}`;
+      console.error(errMsg);
       throw error;
     }
   } finally {
@@ -89,20 +88,6 @@ describe("runtime-entrypoint-tests", () => {
     process.chdir("../../../..");
   });
 
-  test("runtime-hello using entrypoints CLI option", async () => {
-    const command = spawn("node_modules/@dbos-inc/dbos-sdk/dist/src/dbos-runtime/cli.js", ["start", "--port", "1234", "--entrypoints", "dist/entrypoint.js"], {
-      env: process.env,
-    });
-    await waitForMessageTest(command, "1234");
-  });
-
-  test("runtime-hello using deprecated entrypoint CLI option", async () => {
-    const command = spawn("node_modules/@dbos-inc/dbos-sdk/dist/src/dbos-runtime/cli.js", ["start", "--port", "1234", "--entrypoint", "dist/entrypoint.js"], {
-      env: process.env,
-    });
-    await waitForMessageTest(command, "1234");
-  });
-
   test("runtime-hello using entrypoint runtimeConfig", async () => {
     const mockDBOSConfigYamlString = `
 database:
@@ -146,7 +131,7 @@ describe("runtime-tests", () => {
   });
 
   test("runtime-hello-jest", () => {
-    execSync("npm run test", { env: process.env });  // Make sure the hello example passes its own tests.
+    execSync("npm run test", { env: process.env }); // Make sure the hello example passes its own tests.
   });
 
   // Attention! this test relies on example/hello/dbos-config.yaml not declaring a port!


### PR DESCRIPTION
Allow the configuration of multiple files to declare DBOS classes. The user experience is:
- Default entry point is `dist/operations.js`
- `runtimeConfig` now accepts a list of `entrypoints`
- Users can override the configuration when starting DBOS Transact with the `--entrypoints` CLI flag
- breaking changes: `--entrypoint` flag and `runtimeconfig.entrypoint` config property are removed