### PR TITLE
Allow Disabling SSL for DB Connections

### DIFF
--- a/dbos-config.schema.json
+++ b/dbos-config.schema.json
@@ -36,6 +36,10 @@
           "type": "string",
           "description": "The name of the system database"
         },
+        "ssl": {
+          "type": "boolean",
+          "description": "Use SSL/TLS to securely connect to the database (default: true)"
+        },
         "ssl_ca": {
           "type": "string",
           "description": "If using SSL/TLS to securely connect to a database, path to an SSL root certificate file"

--- a/packages/create/templates/hello/dbos-config.yaml
+++ b/packages/create/templates/hello/dbos-config.yaml
@@ -11,6 +11,7 @@ database:
   app_db_name: hello
   connectionTimeoutMillis: 3000
   app_db_client: knex
+  ssl: false
   migrate:
     - npx knex migrate:latest
   rollback:

--- a/packages/create/templates/hello/dbos-config.yaml
+++ b/packages/create/templates/hello/dbos-config.yaml
@@ -11,7 +11,6 @@ database:
   app_db_name: hello
   connectionTimeoutMillis: 3000
   app_db_client: knex
-  ssl: false
   migrate:
     - npx knex migrate:latest
   rollback:

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -120,7 +120,7 @@ export function constructPoolConfig(configFile: ConfigFile, useProxy: boolean = 
   } else if (configFile.database.ssl_ca) {
     // If an SSL certificate is provided, connect to Postgres using TLS and verify the server certificate. (equivalent to verify-full)
     poolConfig.ssl = { ca: [readFileSync(configFile.database.ssl_ca)], rejectUnauthorized: true };
-  } else if (configFile.database.ssl !== true && (poolConfig.host === "localhost" || poolConfig.host === "127.0.0.1")) {
+  } else if (configFile.database.ssl === undefined && (poolConfig.host === "localhost" || poolConfig.host === "127.0.0.1")) {
     // For local development only, do not use TLS unless it is specifically asked for (to support Dockerized Postgres, which does not support SSL connections)
     poolConfig.ssl = false;
   } else {

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -22,6 +22,7 @@ export interface ConfigFile {
     connectionTimeoutMillis?: number;
     app_db_name: string;
     sys_db_name?: string;
+    ssl?: boolean;
     ssl_ca?: string;
     app_db_client?: UserDatabaseName;
     migrate?: string[];
@@ -113,15 +114,18 @@ export function constructPoolConfig(configFile: ConfigFile, useProxy: boolean = 
   }
 
   // Details on Postgres SSL/TLS modes: https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION
-  if (configFile.database.ssl_ca) {
+  if (configFile.database.ssl === false) {
+    // If SSL is set to false, do not use TLS
+    poolConfig.ssl = false
+  } else if (configFile.database.ssl_ca) {
     // If an SSL certificate is provided, connect to Postgres using TLS and verify the server certificate. (equivalent to verify-full)
     poolConfig.ssl = { ca: [readFileSync(configFile.database.ssl_ca)], rejectUnauthorized: true };
-  } else if (poolConfig.host != "localhost" && poolConfig.host != "127.0.0.1") {
+  } else if (configFile.database.ssl !== true && (poolConfig.host === "localhost" || poolConfig.host === "127.0.0.1")) {
+    // For local development only, do not use TLS unless it is specifically asked for (to support Dockerized Postgres, which does not support SSL connections)
+    poolConfig.ssl = false;
+  } else {
     // Otherwise, connect to Postgres using TLS but do not verify the server certificate. (equivalent to require)
     poolConfig.ssl = { rejectUnauthorized: false };
-  } else {
-    // For local development only, do not use TLS (to support Dockerized Postgres, which does not support SSL connections)
-    poolConfig.ssl = false;
   }
   return poolConfig;
 }


### PR DESCRIPTION
This PR allows disabling SSL/TLS for DB connections, for example for local development, through the new `ssl` configuration parameter.  For security, SSL remains on by default and is always used in DBOS Cloud.  Addresses https://github.com/dbos-inc/dbos-transact/issues/397.