### PR TITLE
Change Application Database Instance

### DIFF
--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -89,7 +89,7 @@ export async function deployAppCode(host: string, rollback: boolean, previousVer
       body.previous_version = previousVersion
     }
 
-    if (targetDatabaseName != null) {
+    if (targetDatabaseName !== null) {
       body.target_database_name = targetDatabaseName;
     }
 
@@ -97,7 +97,7 @@ export async function deployAppCode(host: string, rollback: boolean, previousVer
     let url = '';
     if (rollback) {
       url = `https://${host}/v1alpha1/${userCredentials.userName}/applications/${appName}/rollback`;
-    } else if (targetDatabaseName != null) {
+    } else if (targetDatabaseName !== null) {
       url = `https://${host}/v1alpha1/${userCredentials.userName}/applications/${appName}/changedbinstance`;
     } else {
       url = `https://${host}/v1alpha1/${userCredentials.userName}/applications/${appName}`;

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -85,11 +85,12 @@ export async function deployAppCode(host: string, rollback: boolean, previousVer
       body.application_archive = await createZipData(logger);
       logger.debug("  ... application zipped.");
     } else {
-      logger.debug(`Restoring previous version ${previousVersion}`);
+      logger.info(`Restoring previous version ${previousVersion}`);
       body.previous_version = previousVersion
     }
 
     if (targetDatabaseName !== null) {
+      logger.info(`Changing database instance for ${appName} to ${targetDatabaseName} and redeploying`)
       body.target_database_name = targetDatabaseName;
     }
 

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -149,7 +149,7 @@ applicationCommands
   .description('Change this application\'s database instance and redeploy it')
   .option('--verbose', 'Verbose log of deployment step')
   .option('-p, --previous-version <string>', 'Specify a previous version to restore')
-  .requiredOption('-d, --database <string>', 'Specify the new database instance for this application')
+  .requiredOption('-d, --database <string>', 'Specify the new database instance name for this application')
   .action(async (options: {verbose?: boolean, previousVersion?: string, database: string}) => {
     const exitCode = await deployAppCode(DBOSCloudHost, false, options.previousVersion ?? null, options.verbose ?? false, options.database);
     process.exit(exitCode);

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -145,6 +145,17 @@ applicationCommands
   });
 
 applicationCommands
+  .command('change-database-instance')
+  .description('Change this application\'s database instance and redeploy it')
+  .option('--verbose', 'Verbose log of deployment step')
+  .option('-p, --previous-version <string>', 'Specify a previous version to restore')
+  .requiredOption('-d, --database <string>', 'Specify the new database instance for this application')
+  .action(async (options: {verbose?: boolean, previousVersion?: string, database: string}) => {
+    const exitCode = await deployAppCode(DBOSCloudHost, false, options.previousVersion ?? null, options.verbose ?? false, options.database);
+    process.exit(exitCode);
+  });
+
+applicationCommands
   .command('delete')
   .description('Delete this application')
   .argument('[string]', 'application name')


### PR DESCRIPTION
This PR implements a command to change the database instance to which an app is connected, redeploying the app in the process (potentially to a previous version).  This is most useful when performing database point-in-time-recovery (https://github.com/dbos-inc/dbos-transact/pull/409), to redeploy the application to the recovered database instance.