### PR TITLE
This PR tries to lower the usage of unnecessary disabling of linting rules

### DIFF
--- a/packages/create/cli.ts
+++ b/packages/create/cli.ts
@@ -12,7 +12,6 @@ const program = new Command();
 /* LOCAL DEVELOPMENT  */
 ////////////////////////
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 import { fileURLToPath } from 'url';
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "package.json")).toString()) as Package;

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -51,7 +51,6 @@ try {
 
 const program = new Command();
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 program.version(packageJson.version);
 
 /////////////////////

--- a/packages/dbos-cloud/cloudutils.ts
+++ b/packages/dbos-cloud/cloudutils.ts
@@ -63,7 +63,6 @@ const consoleFormat = format.combine(
 
     const messageString: string = typeof message === "string" ? message : JSON.stringify(message);
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     return `${ts} [${level}]: ${messageString} ${stack ? "\n" + formattedStack : ""}`;
   })
 );

--- a/src/communicator.ts
+++ b/src/communicator.ts
@@ -35,9 +35,6 @@ export class CommunicatorContextImpl extends DBOSContextImpl implements Communic
     this.intervalSeconds = params.intervalSeconds ?? 1;
     this.maxAttempts = params.maxAttempts ?? 3;
     this.backoffRate = params.backoffRate ?? 2;
-    if (workflowContext.applicationConfig) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      this.applicationConfig = workflowContext.applicationConfig;
-    }
+    this.applicationConfig = workflowContext.applicationConfig;
   }
 }

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -114,8 +114,10 @@ export class DBOSExecutor {
     [
       DBOSExecutor.tempWorkflowName,
       {
-        // eslint-disable-next-line @typescript-eslint/require-await
-        workflow: async () => this.logger.error("UNREACHABLE: Indirect invoke of temp workflow"),
+        workflow: async () => {
+          this.logger.error("UNREACHABLE: Indirect invoke of temp workflow")
+          return Promise.resolve()
+        },
         config: {},
       },
     ],

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -484,7 +484,6 @@ export class DBOSExecutor {
   /**
    * DEBUG MODE workflow execution, skipping all the recording
    */
-  // eslint-disable-next-line @typescript-eslint/require-await
   async debugWorkflow<T extends any[], R>(wf: Workflow<T, R>, params: WorkflowParams, callerUUID?: string, callerFunctionID?: number, ...args: T): Promise<WorkflowHandle<R>> {
     // In debug mode, we must have a specific workflow UUID.
     if (!params.workflowUUID) {

--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -245,11 +245,10 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
     return new RetrievedHandleDebug(this.#dbosExec.systemDatabase, targetUUID, this.workflowUUID, functionID);
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   async sleep(_: number): Promise<void> {
     // Need to increment function ID for faithful replay.
     this.functionIDGetIncrement();
-    return;
+    return Promise.resolve();
   }
 }
 

--- a/src/foundationdb/fdb_system_database.ts
+++ b/src/foundationdb/fdb_system_database.ts
@@ -60,9 +60,9 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
 
   async init(): Promise<void> {}
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   async destroy(): Promise<void> {
     this.dbRoot.close();
+    return Promise.resolve()
   }
 
   async checkWorkflowOutput<R>(workflowUUID: string): Promise<R | DBOSNull> {
@@ -161,7 +161,6 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
   async flushWorkflowInputsBuffer(): Promise<void> {
     const localBuffer = new Map(this.workflowInputsBuffer);
     this.workflowInputsBuffer.clear();
-    // eslint-disable-next-line @typescript-eslint/require-await
     await this.workflowInputsDB.doTransaction(async (txn) => {
       for (const [workflowUUID, args] of localBuffer) {
         const inputs = await txn.get(workflowUUID);

--- a/src/telemetry/collector.ts
+++ b/src/telemetry/collector.ts
@@ -25,11 +25,10 @@ export class TelemetryCollector {
   // Signals buffer management
   private readonly signals: SignalsQueue = new SignalsQueue();
   private readonly signalBufferID: NodeJS.Timeout;
-  
-  // We iterate on an interval and export whatever has accumulated so far 
+
+  // We iterate on an interval and export whatever has accumulated so far
   private readonly processAndExportSignalsIntervalMs = 100;
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(readonly exporter?: ITelemetryExporter) {
     this.signalBufferID = setInterval(() => {
       void this.processAndExportSignals();

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -38,9 +38,6 @@ export class TransactionContextImpl<T extends UserDatabaseClient> extends DBOSCo
     operationName: string
   ) {
     super(operationName, span, logger, workflowContext);
-    if (workflowContext.applicationConfig) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      this.applicationConfig = workflowContext.applicationConfig;
-    }
+    this.applicationConfig = workflowContext.applicationConfig;
   }
 }

--- a/src/user_database.ts
+++ b/src/user_database.ts
@@ -135,13 +135,12 @@ export class PGNodeUserDatabase implements UserDatabase {
     return pge === "23505";
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   async createSchema(): Promise<void> {
-    throw new Error("createSchema() is not supported in PG user database.");
+    return Promise.reject(new Error("createSchema() is not supported in PG user database."));
   }
-  // eslint-disable-next-line @typescript-eslint/require-await
+
   async dropSchema(): Promise<void> {
-    throw new Error("dropSchema() is not supported in PG user database.");
+    return Promise.reject( new Error("dropSchema() is not supported in PG user database."));
   }
 }
 
@@ -189,7 +188,6 @@ export class PrismaUserDatabase implements UserDatabase {
   }
 
   async transaction<R, T extends unknown[]>(transaction: UserDatabaseTransaction<R, T>, config: TransactionConfig, ...args: T): Promise<R> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     let isolationLevel: string;
     if (config.isolationLevel === IsolationLevel.ReadUncommitted) {
       isolationLevel = PrismaIsolationLevel.ReadUncommitted;
@@ -238,13 +236,12 @@ export class PrismaUserDatabase implements UserDatabase {
     return pge === "23505";
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   async createSchema(): Promise<void> {
-    throw new Error("createSchema() is not supported in Prisma user database.");
+    return Promise.reject(new Error("createSchema() is not supported in Prisma user database."));
   }
-  // eslint-disable-next-line @typescript-eslint/require-await
+
   async dropSchema(): Promise<void> {
-    throw new Error("dropSchema() is not supported in Prisma user database.");
+    return Promise.reject(new Error("dropSchema() is not supported in Prisma user database."));
   }
 }
 
@@ -380,7 +377,6 @@ export class KnexUserDatabase implements UserDatabase {
   }
 
   async transaction<R, T extends unknown[]>(transactionFunction: UserDatabaseTransaction<R, T>, config: TransactionConfig, ...args: T): Promise<R> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     let isolationLevel: Knex.IsolationLevels;
     if (config.isolationLevel === IsolationLevel.ReadUncommitted) {
       isolationLevel = "read uncommitted";
@@ -438,12 +434,11 @@ export class KnexUserDatabase implements UserDatabase {
     return pge === "23505";
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   async createSchema(): Promise<void> {
-    throw new Error("createSchema() is not supported in Knex user database.");
+    return Promise.reject(new Error("createSchema() is not supported in Knex user database."));
   }
-  // eslint-disable-next-line @typescript-eslint/require-await
+
   async dropSchema(): Promise<void> {
-    throw new Error("dropSchema() is not supported in Knex user database.");
+    return Promise.reject(new Error("dropSchema() is not supported in Knex user database."));
   }
 }

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -130,11 +130,10 @@ class ConcurrTestClass {
     await ctxt.invoke(ConcurrTestClass).testReadWriteFunction(1);
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @Communicator()
   static async testCommunicator(_ctxt: CommunicatorContext, id: number) {
     ConcurrTestClass.cnt++;
-    return id;
+    return Promise.resolve(id);
   }
 
   @Workflow()

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -297,7 +297,7 @@ class DBOSTestClass {
   @Communicator()
   static async testCommunicator(ctxt: CommunicatorContext) {
     expect(ctxt.getConfig<number>("counter")).toBe(3);
-    return Promise.resolve((DBOSTestClass.cnt++));
+    return Promise.resolve(DBOSTestClass.cnt++);
   }
 
   @Workflow()

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -251,16 +251,14 @@ class DBOSTestClass {
     return funcResult;
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @Transaction()
   static async testVoidFunction(_txnCtxt: TestTransactionContext) {
-    return;
+    return Promise.resolve();
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @Transaction()
   static async testNameFunction(_txnCtxt: TestTransactionContext, name: string) {
-    return name;
+    return Promise.resolve(name);
   }
 
   @Workflow()
@@ -296,11 +294,10 @@ class DBOSTestClass {
     return checkResult;
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @Communicator()
   static async testCommunicator(ctxt: CommunicatorContext) {
     expect(ctxt.getConfig<number>("counter")).toBe(3);
-    return DBOSTestClass.cnt++;
+    return Promise.resolve((DBOSTestClass.cnt++));
   }
 
   @Workflow()

--- a/tests/failures.test.ts
+++ b/tests/failures.test.ts
@@ -44,7 +44,7 @@ describe("failures-tests", () => {
 
     // Test without code.
     const wfUUID = uuidv1();
-    await expect(testRuntime.invoke(FailureTestClass, wfUUID).testCommunicator()).rejects.toThrow(new DBOSError("test dbos error without code"));
+    await expect(testRuntime.invoke(FailureTestClass, wfUUID).testCommunicator()).rejects.toThrow(new DBOSError("test dbos error without code."));
   });
 
   test("readonly-error", async () => {

--- a/tests/failures.test.ts
+++ b/tests/failures.test.ts
@@ -124,7 +124,6 @@ describe("failures-tests", () => {
     expect(FailureTestClass.cnt).toBe(1);
   });
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   test("no-registration", async () => {
     // Note: since we use invoke() in testing runtime, it throws "TypeError: ...is not a function" instead of NotRegisteredError.
 
@@ -143,21 +142,18 @@ class FailureTestClass {
   static cnt = 0;
   static success: string = "";
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @Communicator({ retriesAllowed: false })
   static async testCommunicator(_ctxt: CommunicatorContext, @ArgOptional code?: number) {
-    if (code) {
-      throw new DBOSError("test dbos error with code.", code);
-    } else {
-      throw new DBOSError("test dbos error without code");
-    }
+    const err = code
+      ? new DBOSError("test dbos error with code.", code)
+      : new DBOSError("test dbos error with code.")
+    return Promise.reject(err)
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @Transaction({ readOnly: true })
   static async testReadonlyError(_txnCtxt: TestTransactionContext) {
     FailureTestClass.cnt++;
-    throw new Error("test error");
+    return Promise.reject(new Error("test error"));
   }
 
   @Transaction()
@@ -168,16 +164,15 @@ class FailureTestClass {
     return rows[0];
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @Transaction()
   static async testSerialError(_ctxt: TestTransactionContext, maxRetry: number) {
     if (FailureTestClass.cnt !== maxRetry) {
       const err = new DatabaseError("serialization error", 10, "error");
       err.code = "40001";
       FailureTestClass.cnt += 1;
-      throw err;
+      return Promise.reject(err);
     }
-    return maxRetry;
+    return Promise.resolve(maxRetry);
   }
 
   @Workflow()
@@ -185,37 +180,32 @@ class FailureTestClass {
     return await ctxt.invoke(FailureTestClass).testSerialError(maxRetry);
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @Communicator({ intervalSeconds: 1, maxAttempts: 2 })
   static async testFailCommunicator(ctxt: CommunicatorContext) {
     FailureTestClass.cnt++;
     if (ctxt.retriesAllowed && FailureTestClass.cnt !== ctxt.maxAttempts) {
       throw new Error("bad number");
     }
-    return FailureTestClass.cnt;
+    return Promise.resolve(FailureTestClass.cnt);
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @Communicator({ retriesAllowed: false })
   static async testNoRetry(_ctxt: CommunicatorContext) {
     FailureTestClass.cnt++;
-    throw new Error("failed no retry");
+    return Promise.reject(new Error("failed no retry"));
   }
 
   // Test decorator registration works.
-  // eslint-disable-next-line @typescript-eslint/require-await
   static async noRegComm(_ctxt: CommunicatorContext, code: number) {
-    return code + 1;
+    return Promise.resolve(code + 1);
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   static async noRegTransaction(_ctxt: TestTransactionContext, code: number) {
-    return code + 1;
+    return Promise.resolve(code + 1);
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   static async noRegWorkflow(_ctxt: WorkflowContext, code: number) {
-    return code + 1;
+    return Promise.resolve(code + 1);
   }
 
   @Workflow()

--- a/tests/failures.test.ts
+++ b/tests/failures.test.ts
@@ -146,7 +146,7 @@ class FailureTestClass {
   static async testCommunicator(_ctxt: CommunicatorContext, @ArgOptional code?: number) {
     const err = code
       ? new DBOSError("test dbos error with code.", code)
-      : new DBOSError("test dbos error with code.")
+      : new DBOSError("test dbos error without code.")
     return Promise.reject(err)
   }
 

--- a/tests/foundationdb/foundationdb.test.ts
+++ b/tests/foundationdb/foundationdb.test.ts
@@ -139,42 +139,37 @@ class FdbTestClass {
   static cnt = 0;
   static wfCnt = 0;
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @Transaction()
   static async testFunction(_txnCtxt: PGTransactionContext) {
     FdbTestClass.cnt++;
-    return 5;
+    return Promise.resolve(5);
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @Transaction()
   static async testErrorFunction(_txnCtxt: PGTransactionContext) {
     if (FdbTestClass.cnt++ === 0) {
-      throw new Error("fail");
+      return Promise.reject(new Error("fail"));
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @Communicator()
   static async testCommunicator(_commCtxt: CommunicatorContext) {
-    return FdbTestClass.cnt++;
+    return Promise.resolve(FdbTestClass.cnt++);
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @Communicator({ intervalSeconds: 0, maxAttempts: 4 })
   static async testErrorCommunicator(ctxt: CommunicatorContext) {
     FdbTestClass.cnt++;
     if (FdbTestClass.cnt !== ctxt.maxAttempts) {
       throw new Error("bad number");
     }
-    return "success";
+    return Promise.resolve("success");
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @Communicator({ retriesAllowed: false })
   static async noRetryComm(_ctxt: CommunicatorContext, id: number) {
     FdbTestClass.cnt++;
-    return id;
+    return Promise.resolve(id);
   }
 
   static innerResolve: () => void;
@@ -187,11 +182,10 @@ class FdbTestClass {
     FdbTestClass.outerResolve = r;
   });
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @Transaction()
   static async testStatusFunc(_txnCtxt: PGTransactionContext) {
     FdbTestClass.cnt++;
-    return 3;
+    return Promise.resolve(3);
   }
 
   @Workflow()

--- a/tests/httpServer/classdec.test.ts
+++ b/tests/httpServer/classdec.test.ts
@@ -126,22 +126,19 @@ describe("httpserver-defsec-tests", () => {
     await next();
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   @DefaultRequiredRole(["user"])
   @Authentication(authTestMiddleware)
   @KoaMiddleware(testMiddleware, testMiddleware2)
   class TestEndpointDefSec {
-    // eslint-disable-next-line @typescript-eslint/require-await
     @RequiredRole([])
     @GetApi("/hello")
     static async hello(_ctx: HandlerContext) {
-      return { message: "hello!" };
+      return Promise.resolve({ message: "hello!" });
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
     @GetApi("/requireduser")
     static async testAuth(_ctxt: HandlerContext, name: string) {
-      return `Please say hello to ${name}`;
+      return Promise.resolve(`Please say hello to ${name}`);
     }
 
     @Transaction()

--- a/tests/httpServer/classdec.test.ts
+++ b/tests/httpServer/classdec.test.ts
@@ -92,23 +92,21 @@ describe("httpserver-defsec-tests", () => {
     );
   });
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   async function authTestMiddleware(ctx: MiddlewareContext) {
     if (ctx.requiredRole.length > 0) {
       const { userid } = ctx.koaContext.request.query;
       const uid = userid?.toString();
 
       if (!uid || uid.length === 0) {
-        const err = new DBOSNotAuthorizedError("Not logged in.", 401);
-        throw err;
+        return Promise.reject(new DBOSNotAuthorizedError("Not logged in.", 401));
       } else {
         if (uid === "go_away") {
-          throw new DBOSNotAuthorizedError("Go away.", 401);
+          return Promise.reject(new DBOSNotAuthorizedError("Go away.", 401));
         }
-        return {
+        return Promise.resolve({
           authenticatedUser: uid,
           authenticatedRoles: uid === "a_real_user" ? ["user"] : ["other"],
-        };
+        });
       }
     }
     return;

--- a/tests/httpServer/cors.test.ts
+++ b/tests/httpServer/cors.test.ts
@@ -251,21 +251,18 @@ describe("http-cors-tests", () => {
   });
 });
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 class TestEndpointsDefCORS {
-  // eslint-disable-next-line @typescript-eslint/require-await
   @GetApi("/hellod")
   static async hello(_ctx: HandlerContext) {
-    return { message: "hello!" };
+    return Promise.resolve({ message: "hello!" });
   }
 }
 
 @KoaCors(cors())
 class TestEndpointsRegCORS {
-  // eslint-disable-next-line @typescript-eslint/require-await
   @GetApi("/hellor")
   static async hello(_ctx: HandlerContext) {
-    return { message: "hello!" };
+    return Promise.resolve({ message: "hello!" });
   }
 }
 
@@ -283,9 +280,8 @@ class TestEndpointsRegCORS {
   allowMethods: 'GET,OPTIONS', // Need to have options for preflight.
 }))
 class TestEndpointsSpecCORS {
-  // eslint-disable-next-line @typescript-eslint/require-await
   @GetApi("/hellos")
   static async hello(_ctx: HandlerContext) {
-    return { message: "hello!" };
+    return Promise.resolve({ message: "hello!" });
   }
 }

--- a/tests/httpServer/validation.test.ts
+++ b/tests/httpServer/validation.test.ts
@@ -382,115 +382,108 @@ describe("httpserver-datavalidation-tests", () => {
   });
   */
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   class TestEndpointDataVal {
-    // eslint-disable-next-line @typescript-eslint/require-await
     @GetApi("/hello")
     static async hello(_ctx: HandlerContext) {
-      return { message: "hello!" };
+      return Promise.resolve({ message: "hello!" });
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
     @GetApi("/string")
     static async checkStringG(_ctx: HandlerContext, v: string) {
       if (typeof v !== "string") {
-        throw new Error("THIS SHOULD NEVER HAPPEN");
+        return Promise.reject(new Error("THIS SHOULD NEVER HAPPEN"));
       }
-      return { message: `This is a really nice string: ${v}` };
+      return Promise.resolve({ message: `This is a really nice string: ${v}` });
     }
-    // eslint-disable-next-line @typescript-eslint/require-await
+
     @PostApi("/string")
     static async checkStringP(_ctx: HandlerContext, v: string) {
       if (typeof v !== "string") {
-        throw new Error("THIS SHOULD NEVER HAPPEN");
+        return Promise.reject(new Error("THIS SHOULD NEVER HAPPEN"));
       }
-      return { message: `This is a really nice string: ${v}` };
+      return Promise.resolve({ message: `This is a really nice string: ${v}` });
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
     @GetApi("/varchar")
     static async checkVarcharG(_ctx: HandlerContext, @ArgVarchar(10) v: string) {
       if (typeof v !== "string") {
-        throw new Error("THIS SHOULD NEVER HAPPEN");
+        return Promise.reject(new Error("THIS SHOULD NEVER HAPPEN"));
       }
-      return { message: `This is a really nice string (limited length): ${v}` };
+      return Promise.resolve({ message: `This is a really nice string (limited length): ${v}` });
     }
-    // eslint-disable-next-line @typescript-eslint/require-await
+
     @PostApi("/varchar")
     static async checkVarcharP(_ctx: HandlerContext, @ArgVarchar(10) v: string) {
       if (typeof v !== "string") {
-        throw new Error("THIS SHOULD NEVER HAPPEN");
+        return Promise.reject(new Error("THIS SHOULD NEVER HAPPEN"));
       }
-      return { message: `This is a really nice string (limited length): ${v}` };
+      return Promise.resolve({ message: `This is a really nice string (limited length): ${v}` });
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
     @GetApi("/number")
     static async checkNumberG(_ctx: HandlerContext, v: number) {
       if (typeof v !== "number") {
-        throw new Error("THIS SHOULD NEVER HAPPEN");
+        return Promise.reject(new Error("THIS SHOULD NEVER HAPPEN"));
       }
-      return { message: `This is a really nice number: ${v}` };
+      return Promise.resolve({ message: `This is a really nice number: ${v}` });
     }
-    // eslint-disable-next-line @typescript-eslint/require-await
+
     @PostApi("/number")
     static async checkNumberP(_ctx: HandlerContext, v: number) {
       if (typeof v !== "number") {
-        throw new Error("THIS SHOULD NEVER HAPPEN");
+        return Promise.reject(new Error("THIS SHOULD NEVER HAPPEN"));
       }
-      return { message: `This is a really nice number: ${v}` };
+      return Promise.resolve({ message: `This is a really nice number: ${v}` });
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
     @GetApi("/bigint")
     static async checkBigintG(_ctx: HandlerContext, v: bigint) {
       if (typeof v !== "bigint") {
-        throw new Error("THIS SHOULD NEVER HAPPEN");
+        return Promise.reject(new Error("THIS SHOULD NEVER HAPPEN"));
       }
-      return { message: `This is a really nice bigint: ${v}` };
+      return Promise.resolve({ message: `This is a really nice bigint: ${v}` });
     }
-    // eslint-disable-next-line @typescript-eslint/require-await
+
     @PostApi("/bigint")
     static async checkBigintP(_ctx: HandlerContext, v: bigint) {
       if (typeof v !== "bigint") {
-        throw new Error("THIS SHOULD NEVER HAPPEN");
+        return Promise.reject(new Error("THIS SHOULD NEVER HAPPEN"));
       }
-      return { message: `This is a really nice bigint: ${v}` };
+      return Promise.resolve({ message: `This is a really nice bigint: ${v}` });
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
     @GetApi("/date")
     static async checkDateG(_ctx: HandlerContext, @ArgDate() v: Date) {
       if (!(v instanceof Date)) {
-        throw new Error("THIS SHOULD NEVER HAPPEN");
+        return Promise.reject(new Error("THIS SHOULD NEVER HAPPEN"));
       }
-      return { message: `This is a really nice date: ${v.toISOString()}` };
+      return Promise.resolve({ message: `This is a really nice date: ${v.toISOString()}` });
     }
-    // eslint-disable-next-line @typescript-eslint/require-await
+
     @PostApi("/date")
     static async checkDateP(_ctx: HandlerContext, @ArgDate() v: Date) {
       if (!(v instanceof Date)) {
-        throw new Error("THIS SHOULD NEVER HAPPEN");
+        return Promise.reject(new Error("THIS SHOULD NEVER HAPPEN"));
       }
-      return { message: `This is a really nice date: ${v.toISOString()}` };
+      return Promise.resolve({ message: `This is a really nice date: ${v.toISOString()}` });
     }
 
     // This is in honor of Harry
-    // eslint-disable-next-line @typescript-eslint/require-await
     @GetApi("/boolean")
     static async checkBooleanG(_ctx: HandlerContext, v: boolean) {
       if (typeof v !== "boolean") {
-        throw new Error("THIS SHOULD NEVER HAPPEN");
+        return Promise.reject(new Error("THIS SHOULD NEVER HAPPEN"));
       }
-      return { message: `This is a really nice boolean: ${v}` };
+      return Promise.resolve({ message: `This is a really nice boolean: ${v}` });
     }
-    // eslint-disable-next-line @typescript-eslint/require-await
+
     @PostApi("/boolean")
     static async checkBooleanP(_ctx: HandlerContext, v: boolean) {
       if (typeof v !== "boolean") {
-        throw new Error("THIS SHOULD NEVER HAPPEN");
+        return Promise.reject(new Error("THIS SHOULD NEVER HAPPEN"));
       }
-      return { message: `This is a really nice boolean: ${v}` };
+      return Promise.resolve({ message: `This is a really nice boolean: ${v}` });
     }
 
     // Types saved for another day - even the decorators are not there yet:
@@ -502,81 +495,71 @@ describe("httpserver-datavalidation-tests", () => {
 
   @DefaultArgRequired
   class DefaultArgToRequired {
-    // eslint-disable-next-line @typescript-eslint/require-await
     @PostApi("/rrequired")
     @Debug()
     static async checkReqValueR(_ctx: HandlerContext, @ArgRequired v: string) {
-      return { message: `Got string ${v}` };
+      return Promise.resolve({ message: `Got string ${v}` });
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
     @PostApi("/roptional")
     @Debug()
     static async checkOptValueR(_ctx: HandlerContext, @ArgOptional v?: string) {
-      return { message: `Got string ${v}` };
+      return Promise.resolve({ message: `Got string ${v}` });
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
     @PostApi("/rdefault")
     @Debug()
     static async checkDefValueR(_ctx: HandlerContext, v?: string) {
-      return { message: `Got string ${v}` };
+      return Promise.resolve({ message: `Got string ${v}` });
     }
   }
 
   @DefaultArgOptional
   class DefaultArgToOptional {
-    // eslint-disable-next-line @typescript-eslint/require-await
     @PostApi("/orequired")
     @Debug()
     static async checkReqValueO(_ctx: HandlerContext, @ArgRequired v: string) {
-      return { message: `Got string ${v}` };
+      return Promise.resolve({ message: `Got string ${v}` });
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
     @PostApi("/ooptional")
     @Debug()
     static async checkOptValueO(_ctx: HandlerContext, @ArgOptional v?: string) {
-      return { message: `Got string ${v}` };
+      return Promise.resolve({ message: `Got string ${v}` });
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
     @PostApi("/odefault")
     @Debug()
     static async checkDefValueO(_ctx: HandlerContext, v?: string) {
-      return { message: `Got string ${v}` };
+      return Promise.resolve({ message: `Got string ${v}` });
     }
   }
 
   class DefaultArgToDefault {
-    // eslint-disable-next-line @typescript-eslint/require-await
     @PostApi("/drequired")
     @Debug()
     static async checkReqValueD(_ctx: HandlerContext, @ArgRequired v: string) {
-      return { message: `Got string ${v}` };
+      return Promise.resolve({ message: `Got string ${v}` });
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
     @PostApi("/doptional")
     @Debug()
     static async checkOptValueD(_ctx: HandlerContext, @ArgOptional v?: string) {
-      return { message: `Got string ${v}` };
+      return Promise.resolve({ message: `Got string ${v}` });
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
     @PostApi("/ddefault")
     @Debug()
     static async checkDefValueD(_ctx: HandlerContext, v?: string) {
-      return { message: `Got string ${v}` };
+      return Promise.resolve({ message: `Got string ${v}` });
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
     @Workflow()
     static async opworkflow(_ctx: WorkflowContext, @ArgOptional v?: string)
     {
-      return {message: v};
+      return Promise.resolve({message: v});
     }
-    
+
     @PostApi("/doworkflow")
     static async doWorkflow(ctx: HandlerContext, @ArgOptional v?: string)
     {

--- a/tests/kafka/kafka.test.ts
+++ b/tests/kafka/kafka.test.ts
@@ -107,7 +107,6 @@ class DBOSTestClass {
     DBOSTestClass.wfResolve = r;
   });
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @KafkaConsume(txnTopic)
   @Transaction()
   static async testTxn(_ctxt: TransactionContext<Knex>, topic: string, _partition: number, message: KafkaMessage) {
@@ -115,9 +114,9 @@ class DBOSTestClass {
       txnCounter = txnCounter + 1;
       DBOSTestClass.txnResolve()
     }
+    return this.txnPromise;
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @KafkaConsume(wfTopic)
   @Workflow()
   static async testWorkflow(_ctxt: WorkflowContext, topic: string, _partition: number, message: KafkaMessage) {
@@ -125,5 +124,6 @@ class DBOSTestClass {
       wfCounter = wfCounter + 1;
       DBOSTestClass.wfResolve()
     }
+    return this.wfPromise;
   }
 }

--- a/tests/knex.test.ts
+++ b/tests/knex.test.ts
@@ -125,11 +125,10 @@ class KUserManager {
     return result;
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @GetApi('/hello')
   @RequiredRole(['user'])
   static async hello(hCtxt: HandlerContext) {
-    return {messge: "hello "+hCtxt.authenticatedUser};
+    return Promise.resolve({messge: "hello "+hCtxt.authenticatedUser});
   }
 
   static async authMiddlware(ctx: MiddlewareContext) {

--- a/tests/oaoo.test.ts
+++ b/tests/oaoo.test.ts
@@ -39,10 +39,9 @@ describe("oaoo-tests", () => {
     static get counter() {
       return CommunicatorOAOO.#counter;
     }
-    // eslint-disable-next-line @typescript-eslint/require-await
     @Communicator()
     static async testCommunicator(_commCtxt: CommunicatorContext) {
-      return CommunicatorOAOO.#counter++;
+      return Promise.resolve(CommunicatorOAOO.#counter++);
     }
 
     @Workflow()
@@ -106,7 +105,6 @@ describe("oaoo-tests", () => {
       return checkResult;
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
     @Workflow()
     static async nestedWorkflow(wfCtxt: WorkflowContext, name: string) {
       return wfCtxt.childWorkflow(WorkflowOAOO.testTxWorkflow, name).then((x) => x.getResult());
@@ -200,7 +198,7 @@ describe("oaoo-tests", () => {
     // Receive twice with the same UUID.  Each should get the same result of true.
     const recvHandle1 = await testRuntime.invoke(NotificationOAOO, recvWorkflowUUID).receiveOaooWorkflow("testTopic", 1);
     const recvHandle2 = await testRuntime.invoke(NotificationOAOO, recvWorkflowUUID).receiveOaooWorkflow("testTopic", 1);
-  
+
     // Send twice with the same idempotency key.  Only one message should be sent.
     await expect(testRuntime.send(recvWorkflowUUID, 123, "testTopic", idempotencyKey)).resolves.not.toThrow();
     await expect(testRuntime.send(recvWorkflowUUID, 123, "testTopic", idempotencyKey)).resolves.not.toThrow();

--- a/tests/oaoo.test.ts
+++ b/tests/oaoo.test.ts
@@ -98,7 +98,6 @@ describe("oaoo-tests", () => {
 
     @Workflow()
     static async testTxWorkflow(wfCtxt: WorkflowContext, name: string) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(wfCtxt.getConfig<number>("counter")).toBe(3);
       const funcResult: number = await wfCtxt.invoke(WorkflowOAOO).testInsertTx(name);
       const checkResult: number = await wfCtxt.invoke(WorkflowOAOO).testReadTx(funcResult);

--- a/tests/prisma.test.ts
+++ b/tests/prisma.test.ts
@@ -146,11 +146,10 @@ class PUserManager {
     return res;
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @GetApi('/hello')
   @RequiredRole(['user'])
   static async hello(hCtxt: HandlerContext) {
-    return {messge: "hello "+hCtxt.authenticatedUser};
+    return Promise.resolve({messge: "hello "+hCtxt.authenticatedUser});
   }
 
   static async authMiddlware(ctx: MiddlewareContext) {

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -98,11 +98,10 @@ describe("debugger-test", () => {
       return val1 + "-" + val2;
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
     @Transaction()
     static async voidFunction(_txnCtxt: TestTransactionContext) {
       if (DebuggerTest.cnt > 0) {
-        return DebuggerTest.cnt;
+        return Promise.resolve(DebuggerTest.cnt);
       }
       DebuggerTest.cnt++;
       return;

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -65,10 +65,9 @@ describe("debugger-test", () => {
       return funcResult;
     }
 
-    // eslint-disable-next-line @typescript-eslint/require-await
     @Communicator()
     static async testCommunicator(_ctxt: CommunicatorContext) {
-      return ++DebuggerTest.cnt;
+      return Promise.resolve(++DebuggerTest.cnt);
     }
 
     @Workflow()
@@ -110,11 +109,10 @@ describe("debugger-test", () => {
     }
 
     // Workflow with different results.
-    // eslint-disable-next-line @typescript-eslint/require-await
     @Workflow()
     static async diffWorkflow(_ctxt: WorkflowContext, num: number) {
       DebuggerTest.cnt += num;
-      return DebuggerTest.cnt;
+      return Promise.resolve(DebuggerTest.cnt);
     }
 
     // Workflow that sleep

--- a/tests/typeorm.test.ts
+++ b/tests/typeorm.test.ts
@@ -50,12 +50,11 @@ class KVController {
     return res.id;
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @Transaction({ readOnly: true })
   static async readTxn(txnCtxt: TestTransactionContext, id: string) {
     globalCnt += 1;
     const kvp = await txnCtxt.client.findOneBy(KV, {id: id});
-    return kvp?.value || "<Not Found>";
+    return Promise.resolve(kvp?.value || "<Not Found>");
   }
 }
 
@@ -133,11 +132,10 @@ class UserManager {
     return res;
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   @GetApi('/hello')
   @RequiredRole(['user'])
   static async hello(hCtxt: HandlerContext) {
-    return {messge: "hello "+hCtxt.authenticatedUser};
+    return Promise.resolve({messge: "hello "+hCtxt.authenticatedUser});
   }
 
   static async authMiddlware(ctx: MiddlewareContext) {


### PR DESCRIPTION
There is more to be done towards enabling typing to as many places as possible.
Two cases draw my attention covering possibly never ending loops with // eslint-disable-next-line no-constant-condition.
At first glance both cases look like asking for a user defined retry strategy instead of a while(true) loop.

