### PR TITLE
Return VSCode Configuration to Template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .dbos/
 .vscode/
+!packages/create/templates/**/.vscode
 
 # Logs
 logs

--- a/packages/create/templates/hello-typeorm/.vscode/extensions.json
+++ b/packages/create/templates/hello-typeorm/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+	// Automatically recommend the DBOS extension to VSCode users.
+	// Documentation on extensions.json: http://go.microsoft.com/fwlink/?LinkId=827846
+	"recommendations": [
+		"dbos-inc.dbos-ttdbg"
+	]
+}

--- a/packages/create/templates/hello-typeorm/.vscode/launch.json
+++ b/packages/create/templates/hello-typeorm/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Automatically configure the VSCode debugger for DBOS projects.
+    // Documentation on launch.json: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "type": "node-terminal",
+        "request": "launch",
+        "name": "Local Debug",
+        "command": "npx dbos start",
+        "preLaunchTask": "npm: build",
+      },
+      {
+        "type": "node-terminal",
+        "request": "launch",
+        "name": "Time Travel Debug",
+        "command": "npx dbos debug -x ${command:dbos-ttdbg.get-proxy-url} -u ${command:dbos-ttdbg.pick-workflow-id}",
+        "preLaunchTask": "npm: build"
+      }
+    ]
+  }

--- a/packages/create/templates/hello-typeorm/.vscode/tasks.json
+++ b/packages/create/templates/hello-typeorm/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+    // Configure the build command for DBOS projects using VSCode.
+    // Documentation on tasks.json: https://code.visualstudio.com/docs/editor/tasks
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "npm: build",
+        "type": "npm",
+        "script": "build",
+        "group": {
+          "kind": "build",
+          "isDefault": true
+        },
+        "problemMatcher": [
+          "$tsc"
+        ]
+      }
+    ]
+  }

--- a/packages/create/templates/hello/.vscode/extensions.json
+++ b/packages/create/templates/hello/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+	// Automatically recommend the DBOS extension to VSCode users.
+	// Documentation on extensions.json: http://go.microsoft.com/fwlink/?LinkId=827846
+	"recommendations": [
+		"dbos-inc.dbos-ttdbg"
+	]
+}

--- a/packages/create/templates/hello/.vscode/launch.json
+++ b/packages/create/templates/hello/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Automatically configure the VSCode debugger for DBOS projects.
+    // Documentation on launch.json: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "type": "node-terminal",
+        "request": "launch",
+        "name": "Local Debug",
+        "command": "npx dbos start",
+        "preLaunchTask": "npm: build",
+      },
+      {
+        "type": "node-terminal",
+        "request": "launch",
+        "name": "Time Travel Debug",
+        "command": "npx dbos debug -x ${command:dbos-ttdbg.get-proxy-url} -u ${command:dbos-ttdbg.pick-workflow-id}",
+        "preLaunchTask": "npm: build"
+      }
+    ]
+  }

--- a/packages/create/templates/hello/.vscode/tasks.json
+++ b/packages/create/templates/hello/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+    // Configure the build command for DBOS projects using VSCode.
+    // Documentation on tasks.json: https://code.visualstudio.com/docs/editor/tasks
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "npm: build",
+        "type": "npm",
+        "script": "build",
+        "group": {
+          "kind": "build",
+          "isDefault": true
+        },
+        "problemMatcher": [
+          "$tsc"
+        ]
+      }
+    ]
+  }


### PR DESCRIPTION
Add a `.vscode` folder to the template to provide helpful defaults to VSCode users building DBOS apps. Addresses https://github.com/dbos-inc/dbos-transact/issues/394.