### PR TITLE
Use dynamic import instead of require

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+./.eslintrc.cjs

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-./.eslintrc.cjs

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -48,6 +48,7 @@ import { serializeError } from 'serialize-error';
 import { exaustiveCheckGuard, sleep } from './utils';
 
 export interface DBOSNull { }
+
 export const dbosNull: DBOSNull = {};
 
 interface DBOSTlsConfig {

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -208,7 +208,7 @@ export class DBOSExecutor {
     const userDBConfig = this.config.poolConfig;
     if (userDbClient === UserDatabaseName.PRISMA) {
       // TODO: make Prisma work with debugger proxy.
-      const PrismaClient = await import("@prisma/client");
+      const PrismaClient = (await import("@prisma/client")).default;
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-call
       this.userDatabase = new PrismaUserDatabase(new PrismaClient.PrismaClient());
       this.logger.debug("Loaded Prisma user database");
@@ -240,7 +240,6 @@ export class DBOSExecutor {
               return await userDBConfig.password()
             },
             database: userDBConfig.database,
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
             entities: this.entities,
             ssl: ssl
           })

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -1,7 +1,6 @@
 import { DBOSInitializationError } from "../error";
 import { findPackageRoot, readFileSync } from "../utils";
-import { DBOSConfig } from "../dbos-executor";
-import { PoolConfig } from "pg";
+import { DBOSConfig, DBOSPoolConfig } from "../dbos-executor";
 import YAML from "yaml";
 import { DBOSRuntimeConfig, defaultEntryPoint } from "./runtime";
 import { UserDatabaseName } from "../user_database";
@@ -89,7 +88,7 @@ export function constructPoolConfig(configFile: ConfigFile, useProxy: boolean = 
     throw new DBOSInitializationError(`DBOS configuration (dbos-config.yaml) does not contain database config`);
   }
 
-  const poolConfig: PoolConfig = {
+  const poolConfig: DBOSPoolConfig = {
     host: configFile.database.hostname,
     port: configFile.database.port,
     user: configFile.database.username,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,3 +76,7 @@ export function DBOSReviver(_key: string, value: unknown): unknown {
   }
   return value;
 }
+
+export function exaustiveCheckGuard(_: never): never {
+  throw new Error('Exaustive matching is not applied');
+}


### PR DESCRIPTION
This PR adds a bit more of type safety.

I had to abandon the PoolConfig since "weirdly" enough the typeorm and pg interfaces don't align in at least two places

one is the type definition of the password property since unfortunately  `() => string | undefined`  !== `() => string | () => undefined` 

and the other being the type definition of the `ssl.pskCallback` function.

I rearranged a few pieces for better readability.

I also added a small utility function that has proven very useful for me when dealing with enum like types.

Let me know what you think.