### PR TITLE
Configurable Application Directory

### DIFF
--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -20,6 +20,7 @@ export interface DBOSCLIStartOptions {
   port?: number;
   loglevel?: string;
   configfile?: string;
+  appDir?: string;
 }
 
 export interface DBOSConfigureOptions {
@@ -44,7 +45,8 @@ program
   .description("Start the server")
   .option("-p, --port <number>", "Specify the port number")
   .option("-l, --loglevel <string>", "Specify log level")
-  .option("-c, --configfile <string>", "Specify the config file path", dbosConfigFilePath)
+  .option("-c, --configfile <string>", "Specify the config file path (DEPRECATED)")
+  .option("-d, --appDir <string>", "Specify the application root directory")
   .action(async (options: DBOSCLIStartOptions) => {
     const [dbosConfig, runtimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(options);
     const runtime = new DBOSRuntime(dbosConfig, runtimeConfig);
@@ -57,7 +59,8 @@ program
   .option("-x, --proxy <string>", "Specify the time-travel debug proxy URL for debugging cloud traces")
   .requiredOption("-u, --uuid <string>", "Specify the workflow UUID to replay")
   .option("-l, --loglevel <string>", "Specify log level")
-  .option("-c, --configfile <string>", "Specify the config file path", dbosConfigFilePath)
+  .option("-c, --configfile <string>", "Specify the config file path (DEPRECATED)")
+  .option("-d, --appDir <string>", "Specify the application root directory")
   .action(async (options: DBOSDebugOptions) => {
     const [dbosConfig, runtimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(options, options.proxy !== undefined);
     await debugWorkflow(dbosConfig, runtimeConfig, options.uuid, options.proxy);

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -151,6 +151,12 @@ function prettyPrintAjvErrors(validate: ValidateFunction<unknown>) {
  * Considers DBOSCLIStartOptions if provided, which takes precedence over config file
  * */
 export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, useProxy: boolean = false): [DBOSConfig, DBOSRuntimeConfig] {
+  if (cliOptions?.configfile) {
+    console.warn("The --configFile option is deprecated. Please use --appDir instead.")
+  }
+  if (cliOptions?.appDir) {
+    process.chdir(cliOptions.appDir)
+  }
   const configFilePath = cliOptions?.configfile ?? dbosConfigFilePath;
   const configFile: ConfigFile | undefined = loadConfigFile(configFilePath);
   if (!configFile) {

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -152,7 +152,7 @@ function prettyPrintAjvErrors(validate: ValidateFunction<unknown>) {
  * */
 export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, useProxy: boolean = false): [DBOSConfig, DBOSRuntimeConfig] {
   if (cliOptions?.configfile) {
-    console.warn("The --configfile option is deprecated. Please use --appDir instead.")
+    console.warn('\x1b[33m%s\x1b[0m', "The --configfile option is deprecated. Please use --appDir instead.");
   }
   if (cliOptions?.appDir) {
     process.chdir(cliOptions.appDir)

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -152,7 +152,7 @@ function prettyPrintAjvErrors(validate: ValidateFunction<unknown>) {
  * */
 export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, useProxy: boolean = false): [DBOSConfig, DBOSRuntimeConfig] {
   if (cliOptions?.configfile) {
-    console.warn("The --configFile option is deprecated. Please use --appDir instead.")
+    console.warn("The --configfile option is deprecated. Please use --appDir instead.")
   }
   if (cliOptions?.appDir) {
     process.chdir(cliOptions.appDir)

--- a/tests/dbos-runtime/runtime.test.ts
+++ b/tests/dbos-runtime/runtime.test.ts
@@ -150,6 +150,18 @@ describe("runtime-tests", () => {
     await waitForMessageTest(command, "1234");
   });
 
+  test("runtime hello with appDir provided as CLI parameter", async () => {
+    process.chdir("../../../..");
+    try {
+      const command = spawn("dist/src/dbos-runtime/cli.js", ["start", "--appDir", "packages/create/templates/hello"], {
+        env: process.env,
+      });
+      await waitForMessageTest(command, "3000");
+    } finally {
+      process.chdir("packages/create/templates/hello");
+    }
+  });
+
   test("runtime hello with port provided in configuration file", async () => {
     const mockDBOSConfigYamlString = `
 database:


### PR DESCRIPTION
Allow specifying an application directory in `npx dbos start` to launch the application in that directory.

```
npx dbos start --appDir <path/to/application>
```

Deprecate the previous `--configFile` option, which had confusing semantics.  Addresses https://github.com/dbos-inc/dbos-transact/issues/399.