### PR TITLE
Workflow Invocation Methods

### DIFF
--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -48,6 +48,9 @@ program
   .option("-c, --configfile <string>", "Specify the config file path (DEPRECATED)")
   .option("-d, --appDir <string>", "Specify the application root directory")
   .action(async (options: DBOSCLIStartOptions) => {
+    if (options?.configfile) {
+      console.warn('\x1b[33m%s\x1b[0m', "The --configfile option is deprecated. Please use --appDir instead.");
+    }
     const [dbosConfig, runtimeConfig]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(options);
     const runtime = new DBOSRuntime(dbosConfig, runtimeConfig);
     await runtime.initAndStart();

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -151,9 +151,6 @@ function prettyPrintAjvErrors(validate: ValidateFunction<unknown>) {
  * Considers DBOSCLIStartOptions if provided, which takes precedence over config file
  * */
 export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, useProxy: boolean = false): [DBOSConfig, DBOSRuntimeConfig] {
-  if (cliOptions?.configfile) {
-    console.warn('\x1b[33m%s\x1b[0m', "The --configfile option is deprecated. Please use --appDir instead.");
-  }
   if (cliOptions?.appDir) {
     process.chdir(cliOptions.appDir)
   }

--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -187,10 +187,19 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
   }
 
   // Invoke the debugWorkflow() function instead.
-  async childWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>> {
+  async startWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>> {
     const funcId = this.functionIDGetIncrement();
     const childUUID: string = this.workflowUUID + "-" + funcId;
     return this.#dbosExec.debugWorkflow(wf, { parentCtx: this, workflowUUID: childUUID }, this.workflowUUID, funcId, ...args);
+  }
+
+  async invokeWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<R> {
+    return this.startWorkflow(wf, ...args).then((handle) => handle.getResult());
+  }
+
+  // Deprecated
+  async childWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>> {
+    return this.startWorkflow(wf, ...args);
   }
 
   async send<T extends NonNullable<any>>(_destinationUUID: string, _message: T, _topic?: string | undefined): Promise<void> {

--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -187,19 +187,19 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
   }
 
   // Invoke the debugWorkflow() function instead.
-  async startWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>> {
+  async startChildWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>> {
     const funcId = this.functionIDGetIncrement();
     const childUUID: string = this.workflowUUID + "-" + funcId;
     return this.#dbosExec.debugWorkflow(wf, { parentCtx: this, workflowUUID: childUUID }, this.workflowUUID, funcId, ...args);
   }
 
-  async invokeWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<R> {
-    return this.startWorkflow(wf, ...args).then((handle) => handle.getResult());
+  async invokeChildWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<R> {
+    return this.startChildWorkflow(wf, ...args).then((handle) => handle.getResult());
   }
 
   // Deprecated
   async childWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>> {
-    return this.startWorkflow(wf, ...args);
+    return this.startChildWorkflow(wf, ...args);
   }
 
   async send<T extends NonNullable<any>>(_destinationUUID: string, _message: T, _topic?: string | undefined): Promise<void> {

--- a/src/httpServer/handler.ts
+++ b/src/httpServer/handler.ts
@@ -23,8 +23,8 @@ type HandlerWfFuncs<T> = {
 export interface HandlerContext extends DBOSContext {
   readonly koaContext: Koa.Context;
   invoke<T extends object>(targetClass: T, workflowUUID?: string): InvokeFuncs<T>;
+  invokeWorkflow<T extends object>(targetClass: T, workflowUUID?: string): InvokeFuncs<T>;
   startWorkflow<T extends object>(targetClass: T, workflowUUID?: string): InvokeFuncs<T>;
-  runWorkflow<T extends object>(targetClass: T, workflowUUID?: string): InvokeFuncs<T>;
   retrieveWorkflow<R>(workflowUUID: string): WorkflowHandle<R>;
   send<T extends NonNullable<any>>(destinationUUID: string, message: T, topic?: string, idempotencyKey?: string): Promise<void>;
   getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds?: number): Promise<T | null>;
@@ -150,7 +150,7 @@ export class HandlerContextImpl extends DBOSContextImpl implements HandlerContex
     return proxy as InvokeFuncs<T>;
   }
 
-  runWorkflow<T extends object>(object: T, workflowUUID?: string): InvokeFuncs<T> {
+  invokeWorkflow<T extends object>(object: T, workflowUUID?: string): InvokeFuncs<T> {
     const ops = getRegisteredOperations(object);
     const proxy: any = {};
     const params = { workflowUUID: workflowUUID, parentCtx: this };

--- a/src/httpServer/handler.ts
+++ b/src/httpServer/handler.ts
@@ -16,7 +16,7 @@ import { APITypes, ArgSources } from "./handlerTypes";
 type WFFunc = (ctxt: WorkflowContext, ...args: any[]) => Promise<any>;
 export type InvokeFuncs<T> = WFInvokeFuncs<T> & HandlerWfFuncs<T>;
 
-type HandlerWfFuncs<T> = {
+export type HandlerWfFuncs<T> = {
   [P in keyof T as T[P] extends WFFunc ? P : never]: T[P] extends WFFunc ? (...args: TailParameters<T[P]>) => Promise<WorkflowHandle<Awaited<ReturnType<T[P]>>>> : never;
 }
 
@@ -117,7 +117,6 @@ export class HandlerContextImpl extends DBOSContextImpl implements HandlerContex
    */
   invoke<T extends object>(object: T, workflowUUID?: string): InvokeFuncs<T> {
     const ops = getRegisteredOperations(object);
-
     const proxy: any = {};
     const params = { workflowUUID: workflowUUID, parentCtx: this };
     for (const op of ops) {

--- a/src/httpServer/handler.ts
+++ b/src/httpServer/handler.ts
@@ -23,8 +23,8 @@ type HandlerWfFuncs<T> = {
 export interface HandlerContext extends DBOSContext {
   readonly koaContext: Koa.Context;
   invoke<T extends object>(targetClass: T, workflowUUID?: string): InvokeFuncs<T>;
-  invokeWorkflow<T extends object>(targetClass: T, workflowUUID?: string): InvokeFuncs<T>;
-  startWorkflow<T extends object>(targetClass: T, workflowUUID?: string): InvokeFuncs<T>;
+  invokeWorkflow<T extends object>(targetClass: T, workflowUUID?: string): HandlerWfFuncs<T>;
+  startWorkflow<T extends object>(targetClass: T, workflowUUID?: string): HandlerWfFuncs<T>;
   retrieveWorkflow<R>(workflowUUID: string): WorkflowHandle<R>;
   send<T extends NonNullable<any>>(destinationUUID: string, message: T, topic?: string, idempotencyKey?: string): Promise<void>;
   getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds?: number): Promise<T | null>;

--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -141,7 +141,7 @@ export class TestingRuntimeImpl implements TestingRuntime {
    * Generate a proxy object for the provided class that wraps direct calls (i.e. OpClass.someMethod(param))
    * to invoke workflows, transactions, and communicators;
    */
-  mainInvoke<T extends object>(object: T, workflowUUID: string | undefined, params: WorkflowInvokeParams | undefined, sync: boolean): InvokeFuncs<T> {
+  mainInvoke<T extends object>(object: T, workflowUUID: string | undefined, params: WorkflowInvokeParams | undefined, asyncWf: boolean): InvokeFuncs<T> {
     const dbosExec = this.getDBOSExec();
     const ops = getRegisteredOperations(object);
 
@@ -156,7 +156,7 @@ export class TestingRuntimeImpl implements TestingRuntime {
 
     const wfParams: WorkflowParams = { workflowUUID: workflowUUID, parentCtx: oc };
     for (const op of ops) {
-      if (sync) {
+      if (asyncWf) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         proxy[op.name] = op.txnConfig
           // eslint-disable-next-line @typescript-eslint/no-unsafe-argument

--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -22,7 +22,7 @@ import { DBOSScheduler } from "../scheduler/scheduler";
  * Create a testing runtime. Warn: this function will drop the existing system DB and create a clean new one. Don't run tests against your production database!
  */
 export async function createTestingRuntime(userClasses: object[], configFilePath: string = dbosConfigFilePath, dropSysDB: boolean = true): Promise<TestingRuntime> {
-  const [ dbosConfig ] = parseConfigFile({configfile: configFilePath});
+  const [dbosConfig] = parseConfigFile({ configfile: configFilePath });
 
   if (dropSysDB) {
     // Drop system database. Testing runtime always uses Postgres for local testing.
@@ -162,12 +162,12 @@ export class TestingRuntimeImpl implements TestingRuntime {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
           ? (...args: any[]) => dbosExec.transaction(op.registeredFunction as Transaction<any[], any>, wfParams, ...args)
           : op.workflowConfig
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-            ? (...args: any[]) => dbosExec.workflow(op.registeredFunction as Workflow<any[], any>, wfParams, ...args)
-            : op.commConfig
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-              ? (...args: any[]) => dbosExec.external(op.registeredFunction as Communicator<any[], any>, wfParams, ...args)
-              : undefined;
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          ? (...args: any[]) => dbosExec.workflow(op.registeredFunction as Workflow<any[], any>, wfParams, ...args)
+          : op.commConfig
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          ? (...args: any[]) => dbosExec.external(op.registeredFunction as Communicator<any[], any>, wfParams, ...args)
+          : undefined;
       } else {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         proxy[op.name] = op.workflowConfig

--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -4,7 +4,7 @@ import { Communicator } from "../communicator";
 import { HTTPRequest, DBOSContextImpl } from "../context";
 import { getRegisteredOperations } from "../decorators";
 import { DBOSConfigKeyTypeError, DBOSError } from "../error";
-import { HandlerWfFuncs, InvokeFuncs } from "../httpServer/handler";
+import { AsyncHandlerWfFuncs, InvokeFuncs, SyncHandlerWfFuncs } from "../httpServer/handler";
 import { DBOSHttpServer } from "../httpServer/server";
 import { DBOSExecutor, DBOSConfig } from "../dbos-executor";
 import { dbosConfigFilePath, parseConfigFile } from "../dbos-runtime/config";
@@ -50,8 +50,8 @@ export interface WorkflowInvokeParams {
 
 export interface TestingRuntime {
   invoke<T extends object>(targetClass: T, workflowUUID?: string, params?: WorkflowInvokeParams): InvokeFuncs<T>;
-  invokeWorkflow<T extends object>(targetClass: T, workflowUUID?: string, params?: WorkflowInvokeParams): HandlerWfFuncs<T>;
-  startWorkflow<T extends object>(targetClass: T, workflowUUID?: string, params?: WorkflowInvokeParams): HandlerWfFuncs<T>;
+  invokeWorkflow<T extends object>(targetClass: T, workflowUUID?: string, params?: WorkflowInvokeParams): SyncHandlerWfFuncs<T>;
+  startWorkflow<T extends object>(targetClass: T, workflowUUID?: string, params?: WorkflowInvokeParams): AsyncHandlerWfFuncs<T>;
   retrieveWorkflow<R>(workflowUUID: string): WorkflowHandle<R>;
   send<T extends NonNullable<any>>(destinationUUID: string, message: T, topic?: string, idempotencyKey?: string): Promise<void>;
   getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds?: number): Promise<T | null>;
@@ -183,12 +183,12 @@ export class TestingRuntimeImpl implements TestingRuntime {
     return this.mainInvoke(object, workflowUUID, params, true);
   }
 
-  startWorkflow<T extends object>(object: T, workflowUUID?: string, params?: WorkflowInvokeParams): HandlerWfFuncs<T> {
+  startWorkflow<T extends object>(object: T, workflowUUID?: string, params?: WorkflowInvokeParams): AsyncHandlerWfFuncs<T> {
     return this.mainInvoke(object, workflowUUID, params, true);
   }
 
-  invokeWorkflow<T extends object>(object: T, workflowUUID?: string, params?: WorkflowInvokeParams): HandlerWfFuncs<T> {
-    return this.mainInvoke(object, workflowUUID, params, false);
+  invokeWorkflow<T extends object>(object: T, workflowUUID?: string, params?: WorkflowInvokeParams): SyncHandlerWfFuncs<T> {
+    return this.mainInvoke(object, workflowUUID, params, false) as unknown as SyncHandlerWfFuncs<T>;
   }
 
   /**

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -62,9 +62,9 @@ export const StatusString = {
 
 export interface WorkflowContext extends DBOSContext {
   invoke<T extends object>(targetClass: T): WFInvokeFuncs<T>;
-  startWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>>;
-  invokeWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<R>;
-  childWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>>; // Deprecated, calls startWorkflow
+  startChildWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>>;
+  invokeChildWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<R>;
+  childWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>>; // Deprecated, calls startChildWorkflow
 
   send<T extends NonNullable<any>>(destinationUUID: string, message: T, topic?: string): Promise<void>;
   recv<T extends NonNullable<any>>(topic?: string, timeoutSeconds?: number): Promise<T | null>;
@@ -242,20 +242,20 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
    * We pass in itself as a parent context and assign the child workflow with a deterministic UUID "this.workflowUUID-functionID".
    * We also pass in its own workflowUUID and function ID so the invoked handle is deterministic.
    */
-  async startWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>> {
+  async startChildWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>> {
     // Note: cannot use invoke for childWorkflow because of potential recursive types on the workflow itself.
     const funcId = this.functionIDGetIncrement();
     const childUUID: string = this.workflowUUID + "-" + funcId;
     return this.#dbosExec.internalWorkflow(wf, { parentCtx: this, workflowUUID: childUUID }, this.workflowUUID, funcId, ...args);
   }
 
-  async invokeWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<R> {
-    return this.startWorkflow(wf, ...args).then((handle) => handle.getResult());
+  async invokeChildWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<R> {
+    return this.startChildWorkflow(wf, ...args).then((handle) => handle.getResult());
   }
 
   // Deprecated
   async childWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>> {
-    return this.startWorkflow(wf, ...args);
+    return this.startChildWorkflow(wf, ...args);
   }
 
   /**

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -62,7 +62,9 @@ export const StatusString = {
 
 export interface WorkflowContext extends DBOSContext {
   invoke<T extends object>(targetClass: T): WFInvokeFuncs<T>;
-  childWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>>;
+  startWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>>;
+  invokeWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<R>;
+  childWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>>; // Deprecated, calls startWorkflow
 
   send<T extends NonNullable<any>>(destinationUUID: string, message: T, topic?: string): Promise<void>;
   recv<T extends NonNullable<any>>(topic?: string, timeoutSeconds?: number): Promise<T | null>;
@@ -237,14 +239,23 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
   /**
    * Invoke another workflow as its child workflow and return a workflow handle.
    * The child workflow is guaranteed to be executed exactly once, even if the workflow is retried with the same UUID.
-   * We pass in itself as a parent context adn assign the child workflow with a deterministic UUID "this.workflowUUID-functionID", which appends a function ID to its own UUID.
+   * We pass in itself as a parent context and assign the child workflow with a deterministic UUID "this.workflowUUID-functionID".
    * We also pass in its own workflowUUID and function ID so the invoked handle is deterministic.
    */
-  async childWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>> {
+  async startWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>> {
     // Note: cannot use invoke for childWorkflow because of potential recursive types on the workflow itself.
     const funcId = this.functionIDGetIncrement();
     const childUUID: string = this.workflowUUID + "-" + funcId;
     return this.#dbosExec.internalWorkflow(wf, { parentCtx: this, workflowUUID: childUUID }, this.workflowUUID, funcId, ...args);
+  }
+
+  async invokeWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<R> {
+    return this.startWorkflow(wf, ...args).then((handle) => handle.getResult());
+  }
+
+  // Deprecated
+  async childWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>> {
+    return this.startWorkflow(wf, ...args);
   }
 
   /**

--- a/tests/concurrency.test.ts
+++ b/tests/concurrency.test.ts
@@ -49,9 +49,8 @@ describe("concurrency-tests", () => {
     // The second transaction should get the correct recorded execution without being executed.
     const uuid = uuidv1();
     await testRuntime
-      .invoke(ConcurrTestClass, uuid)
-      .testWorkflow()
-      .then((x) => x.getResult());
+      .invokeWorkflow(ConcurrTestClass, uuid)
+      .testWorkflow();
     const handle = await testRuntime.invoke(ConcurrTestClass, uuid).testWorkflow();
     await ConcurrTestClass.promise2;
 
@@ -83,8 +82,8 @@ describe("concurrency-tests", () => {
     // It's a bit hard to trigger conflicting send because the transaction runs quickly.
     const recvUUID = uuidv1();
     const recvResPromise = Promise.allSettled([
-      testRuntime.invoke(ConcurrTestClass, recvUUID).receiveWorkflow( "testTopic", 2).then((x) => x.getResult()),
-      testRuntime.invoke(ConcurrTestClass, recvUUID).receiveWorkflow( "testTopic", 2).then((x) => x.getResult()),
+      testRuntime.invokeWorkflow(ConcurrTestClass, recvUUID).receiveWorkflow( "testTopic", 2),
+      testRuntime.invokeWorkflow(ConcurrTestClass, recvUUID).receiveWorkflow( "testTopic", 2),
     ]);
 
     // Send would trigger both to receive, but only one can succeed.

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -31,7 +31,7 @@ describe("dbos-tests", () => {
   });
 
   test("simple-function", async () => {
-    const workflowHandle: WorkflowHandle<string> = await testRuntime.invoke(DBOSTestClass).testWorkflow(username);
+    const workflowHandle: WorkflowHandle<string> = await testRuntime.startWorkflow(DBOSTestClass).testWorkflow(username);
     const workflowResult: string = await workflowHandle.getResult();
     expect(JSON.parse(workflowResult)).toEqual({ current_user: username });
   });
@@ -69,13 +69,13 @@ describe("dbos-tests", () => {
     await expect(testRuntime.invokeWorkflow(DBOSTestClass).sendWorkflow('1234567')).rejects.toThrow('Sent to non-existent destination workflow UUID');
 
     const workflowUUID = uuidv1();
-    const handle = await testRuntime.invoke(DBOSTestClass, workflowUUID).receiveWorkflow();
+    const handle = await testRuntime.startWorkflow(DBOSTestClass, workflowUUID).receiveWorkflow();
     await expect(testRuntime.invokeWorkflow(DBOSTestClass).sendWorkflow(handle.getWorkflowUUID())).resolves.toBeFalsy(); // return void.
     expect(await handle.getResult()).toBe(true);
   });
 
   test("simple-workflow-events", async () => {
-    const handle: WorkflowHandle<number> = await testRuntime.invoke(DBOSTestClass).setEventWorkflow();
+    const handle: WorkflowHandle<number> = await testRuntime.startWorkflow(DBOSTestClass).setEventWorkflow();
     const workflowUUID = handle.getWorkflowUUID();
     await handle.getResult();
     await expect(testRuntime.getEvent(workflowUUID, "key1")).resolves.toBe("value1");
@@ -189,7 +189,7 @@ describe("dbos-tests", () => {
   test("retrieve-workflowstatus", async () => {
     const workflowUUID = uuidv1();
 
-    const workflowHandle = await testRuntime.invoke(RetrieveWorkflowStatus, workflowUUID).testStatusWorkflow(123, "hello");
+    const workflowHandle = await testRuntime.startWorkflow(RetrieveWorkflowStatus, workflowUUID).testStatusWorkflow(123, "hello");
 
     expect(workflowHandle.getWorkflowUUID()).toBe(workflowUUID);
     await expect(workflowHandle.getStatus()).resolves.toMatchObject({

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -45,7 +45,7 @@ describe("dbos-tests", () => {
 
   test("tight-loop", async () => {
     for (let i = 0; i < 100; i++) {
-      await expect(testRuntime.invoke(DBOSTestClass).testNameWorkflow(username).then((x) => x.getResult())).resolves.toBe(username);
+      await expect(testRuntime.invokeWorkflow(DBOSTestClass).testNameWorkflow(username)).resolves.toBe(username);
     }
   });
 

--- a/tests/failures.test.ts
+++ b/tests/failures.test.ts
@@ -95,9 +95,8 @@ describe("failures-tests", () => {
     // Should succeed after retrying 10 times.
     await expect(
       testRuntime
-        .invoke(FailureTestClass)
+        .invokeWorkflow(FailureTestClass)
         .testSerialWorkflow(10)
-        .then((x) => x.getResult())
     ).resolves.toBe(10);
     expect(FailureTestClass.cnt).toBe(10);
   });
@@ -134,7 +133,7 @@ describe("failures-tests", () => {
     expect(() => testRuntime.invoke(FailureTestClass).noRegTransaction(10)).toThrow();
 
     // Invoke an unregistered communicator in a workflow.
-    await expect(testRuntime.invoke(FailureTestClass).testCommWorkflow().then(x => x.getResult())).rejects.toThrow();
+    await expect(testRuntime.invokeWorkflow(FailureTestClass).testCommWorkflow()).rejects.toThrow();
   });
 });
 

--- a/tests/foundationdb/fdb_oaoo.test.ts
+++ b/tests/foundationdb/fdb_oaoo.test.ts
@@ -62,7 +62,7 @@ describe("foundationdb-oaoo", () => {
       }
 
       // Note: the targetUUID must match the child workflow UUID.
-      const invokedHandle = await ctxt.startWorkflow(EventStatusOAOO.setEventWorkflow);
+      const invokedHandle = await ctxt.startChildWorkflow(EventStatusOAOO.setEventWorkflow);
       try {
         if (EventStatusOAOO.wfCnt > 2) {
           await invokedHandle.getResult();

--- a/tests/foundationdb/fdb_oaoo.test.ts
+++ b/tests/foundationdb/fdb_oaoo.test.ts
@@ -62,7 +62,7 @@ describe("foundationdb-oaoo", () => {
       }
 
       // Note: the targetUUID must match the child workflow UUID.
-      const invokedHandle = await ctxt.childWorkflow(EventStatusOAOO.setEventWorkflow);
+      const invokedHandle = await ctxt.startWorkflow(EventStatusOAOO.setEventWorkflow);
       try {
         if (EventStatusOAOO.wfCnt > 2) {
           await invokedHandle.getResult();

--- a/tests/foundationdb/fdb_oaoo.test.ts
+++ b/tests/foundationdb/fdb_oaoo.test.ts
@@ -90,9 +90,8 @@ describe("foundationdb-oaoo", () => {
 
     await expect(
       testRuntime
-        .invoke(EventStatusOAOO, getUUID)
+        .invokeWorkflow(EventStatusOAOO, getUUID)
         .getEventRetrieveWorkflow(setUUID)
-        .then((x) => x.getResult())
     ).resolves.toBe("valueNull-statusNull-PENDING");
     expect(EventStatusOAOO.wfCnt).toBe(2);
     await expect(testRuntime.getEvent(setUUID, "key1")).resolves.toBe("value1");
@@ -106,17 +105,15 @@ describe("foundationdb-oaoo", () => {
     // Run without UUID, should get the new result.
     await expect(
       testRuntime
-        .invoke(EventStatusOAOO)
+        .invokeWorkflow(EventStatusOAOO)
         .getEventRetrieveWorkflow(setUUID)
-        .then((x) => x.getResult())
     ).resolves.toBe("value1-ERROR-ERROR");
 
     // Test OAOO for getEvent and getWorkflowStatus.
     await expect(
       testRuntime
-        .invoke(EventStatusOAOO, getUUID)
+        .invokeWorkflow(EventStatusOAOO, getUUID)
         .getEventRetrieveWorkflow(setUUID)
-        .then((x) => x.getResult())
     ).resolves.toBe("valueNull-statusNull-PENDING");
     expect(EventStatusOAOO.wfCnt).toBe(6); // Should re-execute the workflow because we're not flushing the result buffer.
   });

--- a/tests/foundationdb/fdb_recovery.test.ts
+++ b/tests/foundationdb/fdb_recovery.test.ts
@@ -62,7 +62,7 @@ describe("foundationdb-recovery", () => {
     // This test simulates a "local" environment because the request parameter does not have an dbos-executor-id header.
     const dbosExec = (testRuntime as TestingRuntimeImpl).getDBOSExec();
 
-    const handle = await testRuntime.invoke(LocalRecovery, undefined, { authenticatedUser: "test_recovery_user", request: { url: "test-recovery-url" } }).testRecoveryWorkflow(5);
+    const handle = await testRuntime.startWorkflow(LocalRecovery, undefined, { authenticatedUser: "test_recovery_user", request: { url: "test-recovery-url" } }).testRecoveryWorkflow(5);
 
     const recoverHandles = await dbosExec.recoverPendingWorkflows();
     await LocalRecovery.promise2; // Wait for the recovery to be done.
@@ -121,10 +121,10 @@ describe("foundationdb-recovery", () => {
     // Invoke a workflow multiple times with different executor IDs, but only recover workflows for a specific executor.
     const dbosExec = (testRuntime as TestingRuntimeImpl).getDBOSExec();
 
-    const localHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "local_user" }).localWorkflow(3);
+    const localHandle = await testRuntime.startWorkflow(ExecutorRecovery, undefined, { authenticatedUser: "local_user" }).localWorkflow(3);
 
     process.env.DBOS__VMID = "fcvm123"
-    const execHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "cloud_user" }).executorWorkflow(5);
+    const execHandle = await testRuntime.startWorkflow(ExecutorRecovery, undefined, { authenticatedUser: "cloud_user" }).executorWorkflow(5);
 
     const recoverHandles = await dbosExec.recoverPendingWorkflows(["fcvm123"]);
     await ExecutorRecovery.promise2; // Wait for the recovery to be done.
@@ -152,7 +152,7 @@ describe("foundationdb-recovery", () => {
     });
 
     process.env.DBOS__VMID = "fcvm123"
-    const execHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "cloud_user" }).executorWorkflow(5);
+    const execHandle = await testRuntime.startWorkflow(ExecutorRecovery, undefined, { authenticatedUser: "cloud_user" }).executorWorkflow(5);
 
     const response = await request(testRuntime.getAdminCallback())
       .post(WorkflowRecoveryUrl)

--- a/tests/httpServer/classdec.test.ts
+++ b/tests/httpServer/classdec.test.ts
@@ -154,9 +154,8 @@ describe("httpserver-defsec-tests", () => {
     @GetApi("/workflow")
     static async testWfEndpoint(ctxt: HandlerContext, name: string) {
       return ctxt
-        .invoke(TestEndpointDefSec)
+        .invokeWorkflow(TestEndpointDefSec)
         .testWorkflow(name)
-        .then((x) => x.getResult());
     }
 
     @GetApi("/transaction")

--- a/tests/httpServer/server.test.ts
+++ b/tests/httpServer/server.test.ts
@@ -115,6 +115,19 @@ describe("httpserver-tests", () => {
     expect(response.text).toBe("hello 1");
   });
 
+  test("endpoint-testRunWorkflow", async () => {
+    const response = await request(testRuntime.getHandlersCallback()).get("/testRunWorkflow/alice");
+    expect(response.statusCode).toBe(200);
+    expect(response.text).toBe("hello 1");
+  });
+
+
+  test("endpoint-testStartWorkflow", async () => {
+    const response = await request(testRuntime.getHandlersCallback()).get("/testStartWorkflow/alice");
+    expect(response.statusCode).toBe(200);
+    expect(response.text).toBe("hello 1");
+  });
+
   // This feels unclean, but supertest doesn't expose the error message the people we want. See:
   //   https://github.com/ladjs/supertest/issues/95
   interface Res {
@@ -271,6 +284,16 @@ describe("httpserver-tests", () => {
         .invoke(TestEndpoints, workflowUUID)
         .testWorkflow(name)
         .then((x) => x.getResult());
+    }
+
+    @GetApi("/testRunWorkflow/:name")
+    static async testRunWorkflow(ctxt: HandlerContext, name: string) {
+      return ctxt.startWorkflow(TestEndpoints).testWorkflow(name).then((x) => x.getResult());
+    }
+
+    @GetApi("/testStartWorkflow/:name")
+    static async testStartWorkflow(ctxt: HandlerContext, name: string) {
+      return ctxt.runWorkflow(TestEndpoints).testWorkflow(name);
     }
 
     @PostApi("/transaction/:name")

--- a/tests/httpServer/server.test.ts
+++ b/tests/httpServer/server.test.ts
@@ -293,7 +293,7 @@ describe("httpserver-tests", () => {
 
     @GetApi("/testStartWorkflow/:name")
     static async testStartWorkflow(ctxt: HandlerContext, name: string) {
-      return ctxt.runWorkflow(TestEndpoints).testWorkflow(name);
+      return ctxt.invokeWorkflow(TestEndpoints).testWorkflow(name);
     }
 
     @PostApi("/transaction/:name")

--- a/tests/httpServer/server.test.ts
+++ b/tests/httpServer/server.test.ts
@@ -115,15 +115,14 @@ describe("httpserver-tests", () => {
     expect(response.text).toBe("hello 1");
   });
 
-  test("endpoint-testRunWorkflow", async () => {
-    const response = await request(testRuntime.getHandlersCallback()).get("/testRunWorkflow/alice");
+  test("endpoint-testStartWorkflow", async () => {
+    const response = await request(testRuntime.getHandlersCallback()).get("/testStartWorkflow/alice");
     expect(response.statusCode).toBe(200);
     expect(response.text).toBe("hello 1");
   });
 
-
-  test("endpoint-testStartWorkflow", async () => {
-    const response = await request(testRuntime.getHandlersCallback()).get("/testStartWorkflow/alice");
+  test("endpoint-testInvokeWorkflow", async () => {
+    const response = await request(testRuntime.getHandlersCallback()).get("/testInvokeWorkflow/alice");
     expect(response.statusCode).toBe(200);
     expect(response.text).toBe("hello 1");
   });
@@ -286,13 +285,13 @@ describe("httpserver-tests", () => {
         .then((x) => x.getResult());
     }
 
-    @GetApi("/testRunWorkflow/:name")
-    static async testRunWorkflow(ctxt: HandlerContext, name: string) {
+    @GetApi("/testStartWorkflow/:name")
+    static async testStartWorkflow(ctxt: HandlerContext, name: string): Promise<string> {
       return ctxt.startWorkflow(TestEndpoints).testWorkflow(name).then((x) => x.getResult());
     }
 
-    @GetApi("/testStartWorkflow/:name")
-    static async testStartWorkflow(ctxt: HandlerContext, name: string) {
+    @GetApi("/testInvokeWorkflow/:name")
+    static async testInvokeWorkflow(ctxt: HandlerContext, name: string): Promise<string> {
       return ctxt.invokeWorkflow(TestEndpoints).testWorkflow(name);
     }
 

--- a/tests/knex.test.ts
+++ b/tests/knex.test.ts
@@ -79,7 +79,7 @@ describe("knex-tests", () => {
   test("simple-knex", async () => {
     await expect(testRuntime.invoke(TestClass).testInsert("test-one")).resolves.toBe(1);
     await expect(testRuntime.invoke(TestClass).testSelect(1)).resolves.toBe("test-one");
-    await expect(testRuntime.invoke(TestClass).testWf("test-two").then((x) => x.getResult())).resolves.toBe("test-two");
+    await expect(testRuntime.invokeWorkflow(TestClass).testWf("test-two")).resolves.toBe("test-two");
   });
 
   test("knex-return-void", async () => {
@@ -89,8 +89,8 @@ describe("knex-tests", () => {
   test("knex-duplicate-workflows", async () => {
     const uuid = uuidv1();
     const results = await Promise.allSettled([
-      testRuntime.invoke(TestClass, uuid).testWf("test-one").then((x) => x.getResult()),
-      testRuntime.invoke(TestClass, uuid).testWf("test-one").then((x) => x.getResult()),
+      testRuntime.invokeWorkflow(TestClass, uuid).testWf("test-one"),
+      testRuntime.invokeWorkflow(TestClass, uuid).testWf("test-one"),
     ]);
     expect((results[0] as PromiseFulfilledResult<string>).value).toBe("test-one");
     expect((results[1] as PromiseFulfilledResult<string>).value).toBe("test-one");

--- a/tests/oaoo.test.ts
+++ b/tests/oaoo.test.ts
@@ -55,22 +55,20 @@ describe("oaoo-tests", () => {
     const workflowUUID: string = uuidv1();
 
     let result: number = await testRuntime
-      .invoke(CommunicatorOAOO, workflowUUID)
-      .testCommWorkflow()
-      .then((x) => x.getResult());
+      .invokeWorkflow(CommunicatorOAOO, workflowUUID)
+      .testCommWorkflow();
     expect(result).toBe(0);
     expect(CommunicatorOAOO.counter).toBe(1);
 
     // Test OAOO. Should return the original result.
     result = await testRuntime
-      .invoke(CommunicatorOAOO, workflowUUID)
-      .testCommWorkflow()
-      .then((x) => x.getResult());
+      .invokeWorkflow(CommunicatorOAOO, workflowUUID)
+      .testCommWorkflow();
     expect(result).toBe(0);
     expect(CommunicatorOAOO.counter).toBe(1);
 
     // Should be a new run.
-    await expect(testRuntime.invoke(CommunicatorOAOO).testCommWorkflow().then(x => x.getResult())).resolves.toBe(1);
+    await expect(testRuntime.invokeWorkflow(CommunicatorOAOO).testCommWorkflow()).resolves.toBe(1);
     expect(CommunicatorOAOO.counter).toBe(2);
   });
 
@@ -119,12 +117,12 @@ describe("oaoo-tests", () => {
   test("workflow-sleep-oaoo", async () => {
     const workflowUUID = uuidv1();
     const initTime = Date.now();
-    await expect(testRuntime.invoke(WorkflowOAOO, workflowUUID).sleepWorkflow(2).then((x) => x.getResult())).resolves.toBeFalsy();
+    await expect(testRuntime.invokeWorkflow(WorkflowOAOO, workflowUUID).sleepWorkflow(2)).resolves.toBeFalsy();
     expect(Date.now() - initTime).toBeGreaterThanOrEqual(1500);
 
     // Rerunning should skip the sleep
     const startTime = Date.now();
-    await expect(testRuntime.invoke(WorkflowOAOO, workflowUUID).sleepWorkflow(2).then((x) => x.getResult())).resolves.toBeFalsy();
+    await expect(testRuntime.invokeWorkflow(WorkflowOAOO, workflowUUID).sleepWorkflow(2)).resolves.toBeFalsy();
     expect(Date.now() - startTime).toBeLessThanOrEqual(1000);
   });
 
@@ -146,9 +144,8 @@ describe("oaoo-tests", () => {
     for (let i = 0; i < 10; i++) {
       const workflowUUID: string = uuidArray[i];
       const workflowResult: number = await testRuntime
-        .invoke(WorkflowOAOO, workflowUUID)
-        .testTxWorkflow(username)
-        .then((x) => x.getResult());
+        .invokeWorkflow(WorkflowOAOO, workflowUUID)
+        .testTxWorkflow(username);
       expect(workflowResult).toEqual(i + 1);
     }
   });
@@ -160,15 +157,13 @@ describe("oaoo-tests", () => {
     const workflowUUID = uuidv1();
     await expect(
       testRuntime
-        .invoke(WorkflowOAOO, workflowUUID)
+        .invokeWorkflow(WorkflowOAOO, workflowUUID)
         .nestedWorkflow(username)
-        .then((x) => x.getResult())
     ).resolves.toBe(1);
     await expect(
       testRuntime
-        .invoke(WorkflowOAOO, workflowUUID)
+        .invokeWorkflow(WorkflowOAOO, workflowUUID)
         .nestedWorkflow(username)
-        .then((x) => x.getResult())
     ).resolves.toBe(1);
 
     // Retrieve output of the child workflow.
@@ -206,7 +201,7 @@ describe("oaoo-tests", () => {
     await expect(recvHandle2.getResult()).resolves.toBe(true)
 
     // A receive with a different UUID should return false.
-    await expect(testRuntime.invoke(NotificationOAOO).receiveOaooWorkflow("testTopic", 0).then((x) => x.getResult())).resolves.toBe(false);
+    await expect(testRuntime.invokeWorkflow(NotificationOAOO).receiveOaooWorkflow("testTopic", 0)).resolves.toBe(false);
   });
 
   /**
@@ -274,7 +269,7 @@ describe("oaoo-tests", () => {
     const getUUID = uuidv1();
     const setUUID = getUUID + "-2";
 
-    await expect(testRuntime.invoke(EventStatusOAOO, getUUID).getEventRetrieveWorkflow(setUUID).then(x => x.getResult())).resolves.toBe("valueNull-statusNull-PENDING");
+    await expect(testRuntime.invokeWorkflow(EventStatusOAOO, getUUID).getEventRetrieveWorkflow(setUUID)).resolves.toBe("valueNull-statusNull-PENDING");
     expect(EventStatusOAOO.wfCnt).toBe(2);
     await expect(testRuntime.getEvent(setUUID, "key1")).resolves.toBe("value1");
 
@@ -285,10 +280,10 @@ describe("oaoo-tests", () => {
     await expect(handle.getResult()).rejects.toThrow("Failed workflow");
 
     // Run without UUID, should get the new result.
-    await expect(testRuntime.invoke(EventStatusOAOO).getEventRetrieveWorkflow(setUUID).then(x => x.getResult())).resolves.toBe("value1-ERROR-ERROR");
+    await expect(testRuntime.invokeWorkflow(EventStatusOAOO).getEventRetrieveWorkflow(setUUID)).resolves.toBe("value1-ERROR-ERROR");
 
     // Test OAOO for getEvent and getWorkflowStatus.
-    await expect(testRuntime.invoke(EventStatusOAOO, getUUID).getEventRetrieveWorkflow(setUUID).then(x => x.getResult())).resolves.toBe("valueNull-statusNull-PENDING");
+    await expect(testRuntime.invokeWorkflow(EventStatusOAOO, getUUID).getEventRetrieveWorkflow(setUUID)).resolves.toBe("valueNull-statusNull-PENDING");
     expect(EventStatusOAOO.wfCnt).toBe(6);  // Should re-execute the workflow because we're not flushing the result buffer.
   });
 

--- a/tests/oaoo.test.ts
+++ b/tests/oaoo.test.ts
@@ -106,7 +106,7 @@ describe("oaoo-tests", () => {
 
     @Workflow()
     static async nestedWorkflow(wfCtxt: WorkflowContext, name: string) {
-      return wfCtxt.childWorkflow(WorkflowOAOO.testTxWorkflow, name).then((x) => x.getResult());
+      return await wfCtxt.invokeWorkflow(WorkflowOAOO.testTxWorkflow, name);
     }
 
     @Workflow()
@@ -248,7 +248,7 @@ describe("oaoo-tests", () => {
       }
 
       // Note: the targetUUID must match the child workflow UUID.
-      const invokedHandle = await ctxt.childWorkflow(EventStatusOAOO.setEventWorkflow);
+      const invokedHandle = await ctxt.startWorkflow(EventStatusOAOO.setEventWorkflow);
       try {
         if (EventStatusOAOO.wfCnt > 2) {
           await invokedHandle.getResult();

--- a/tests/oaoo.test.ts
+++ b/tests/oaoo.test.ts
@@ -132,7 +132,7 @@ describe("oaoo-tests", () => {
 
     for (let i = 0; i < 10; i++) {
       const workflowHandle = await testRuntime
-        .invoke(WorkflowOAOO)
+        .startWorkflow(WorkflowOAOO)
         .testTxWorkflow(username);
       const workflowUUID: string = workflowHandle.getWorkflowUUID()
       uuidArray.push(workflowUUID);
@@ -190,8 +190,8 @@ describe("oaoo-tests", () => {
     const idempotencyKey = "test-suffix";
 
     // Receive twice with the same UUID.  Each should get the same result of true.
-    const recvHandle1 = await testRuntime.invoke(NotificationOAOO, recvWorkflowUUID).receiveOaooWorkflow("testTopic", 1);
-    const recvHandle2 = await testRuntime.invoke(NotificationOAOO, recvWorkflowUUID).receiveOaooWorkflow("testTopic", 1);
+    const recvHandle1 = await testRuntime.startWorkflow(NotificationOAOO, recvWorkflowUUID).receiveOaooWorkflow("testTopic", 1);
+    const recvHandle2 = await testRuntime.startWorkflow(NotificationOAOO, recvWorkflowUUID).receiveOaooWorkflow("testTopic", 1);
 
     // Send twice with the same idempotency key.  Only one message should be sent.
     await expect(testRuntime.send(recvWorkflowUUID, 123, "testTopic", idempotencyKey)).resolves.not.toThrow();

--- a/tests/oaoo.test.ts
+++ b/tests/oaoo.test.ts
@@ -106,7 +106,7 @@ describe("oaoo-tests", () => {
 
     @Workflow()
     static async nestedWorkflow(wfCtxt: WorkflowContext, name: string) {
-      return await wfCtxt.invokeWorkflow(WorkflowOAOO.testTxWorkflow, name);
+      return await wfCtxt.invokeChildWorkflow(WorkflowOAOO.testTxWorkflow, name);
     }
 
     @Workflow()
@@ -248,7 +248,7 @@ describe("oaoo-tests", () => {
       }
 
       // Note: the targetUUID must match the child workflow UUID.
-      const invokedHandle = await ctxt.startWorkflow(EventStatusOAOO.setEventWorkflow);
+      const invokedHandle = await ctxt.startChildWorkflow(EventStatusOAOO.setEventWorkflow);
       try {
         if (EventStatusOAOO.wfCnt > 2) {
           await invokedHandle.getResult();

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -60,7 +60,7 @@ describe("recovery-tests", () => {
     // Run a workflow until pending and start recovery.
     const dbosExec = (testRuntime as TestingRuntimeImpl).getDBOSExec();
 
-    const handle = await testRuntime.invoke(LocalRecovery, undefined, { authenticatedUser: "test_recovery_user", request: { url: "test-recovery-url" } }).testRecoveryWorkflow(5);
+    const handle = await testRuntime.startWorkflow(LocalRecovery, undefined, { authenticatedUser: "test_recovery_user", request: { url: "test-recovery-url" } }).testRecoveryWorkflow(5);
 
     const recoverHandles = await dbosExec.recoverPendingWorkflows();
     await LocalRecovery.promise2; // Wait for the recovery to be done.
@@ -79,7 +79,7 @@ describe("recovery-tests", () => {
     // Run a workflow until pending and start recovery. We should skip the recovery since the DBOS__VMID is not empty.
     const dbosExec = (testRuntime as TestingRuntimeImpl).getDBOSExec();
 
-    const handle = await testRuntime.invoke(LocalRecovery, undefined, { authenticatedUser: "test_recovery_user", request: { url: "test-recovery-url" } }).testRecoveryWorkflow(5);
+    const handle = await testRuntime.startWorkflow(LocalRecovery, undefined, { authenticatedUser: "test_recovery_user", request: { url: "test-recovery-url" } }).testRecoveryWorkflow(5);
 
     const recoverHandles = await dbosExec.recoverPendingWorkflows();
 
@@ -136,7 +136,7 @@ describe("recovery-tests", () => {
     // Invoke a workflow multiple times with different executor IDs, but only recover workflows for a specific executor.
     const dbosExec = (testRuntime as TestingRuntimeImpl).getDBOSExec();
 
-    const localHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "local_user" }).localWorkflow(3);
+    const localHandle = await testRuntime.startWorkflow(ExecutorRecovery, undefined, { authenticatedUser: "local_user" }).localWorkflow(3);
 
     process.env.DBOS__VMID = "fcvm123"
     const execHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "cloud_user" }).executorWorkflow(5);
@@ -167,7 +167,7 @@ describe("recovery-tests", () => {
     });
 
     process.env.DBOS__VMID = "fcvm123"
-    const execHandle = await testRuntime.invoke(ExecutorRecovery, undefined, { authenticatedUser: "cloud_user" }).executorWorkflow(5);
+    const execHandle = await testRuntime.startWorkflow(ExecutorRecovery, undefined, { authenticatedUser: "cloud_user" }).executorWorkflow(5);
 
     const response = await request(testRuntime.getAdminCallback())
       .post(WorkflowRecoveryUrl)

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -127,17 +127,15 @@ describe("debugger-test", () => {
     const wfUUID = uuidv1();
     // Execute the workflow and destroy the runtime
     const res = await testRuntime
-      .invoke(DebuggerTest, wfUUID)
-      .testWorkflow(username)
-      .then((x) => x.getResult());
+      .invokeWorkflow(DebuggerTest, wfUUID)
+      .testWorkflow(username);
     expect(res).toBe(1);
     await testRuntime.destroy();
 
     // Execute again in debug mode.
     const debugRes = await debugRuntime
-      .invoke(DebuggerTest, wfUUID)
-      .testWorkflow(username)
-      .then((x) => x.getResult());
+      .invokeWorkflow(DebuggerTest, wfUUID)
+      .testWorkflow(username);
     expect(debugRes).toBe(1);
 
     // Execute again with the provided UUID.
@@ -157,24 +155,21 @@ describe("debugger-test", () => {
     const wfUUID = uuidv1();
     // Execute the workflow and destroy the runtime
     const res = await testRuntime
-      .invoke(DebuggerTest, wfUUID)
-      .sleepWorkflow(2)
-      .then((x) => x.getResult());
+      .invokeWorkflow(DebuggerTest, wfUUID)
+      .sleepWorkflow(2);
     expect(res).toBe(3);
     await testRuntime.destroy();
 
     // Execute again in debug mode, should return the correct value
     const debugRes = await debugRuntime
-      .invoke(DebuggerTest, wfUUID)
-      .sleepWorkflow(2)
-      .then((x) => x.getResult());
+      .invokeWorkflow(DebuggerTest, wfUUID)
+      .sleepWorkflow(2);
     expect(debugRes).toBe(3);
 
     // Proxy mode should return the same result
     const debugProxyRes = await debugProxyRuntime
-      .invoke(DebuggerTest, wfUUID)
-      .sleepWorkflow(2)
-      .then((x) => x.getResult());
+      .invokeWorkflow(DebuggerTest, wfUUID)
+      .sleepWorkflow(2);
     expect(debugProxyRes).toBe(3);
   });
 
@@ -265,33 +260,32 @@ describe("debugger-test", () => {
     const sendUUID = uuidv1();
     // Execute the workflow and destroy the runtime
     const handle = await testRuntime.invoke(DebuggerTest, recvUUID).receiveWorkflow();
-    await expect(testRuntime.invoke(DebuggerTest, sendUUID).sendWorkflow(recvUUID).then((x) => x.getResult())).resolves.toBeFalsy(); // return void.
+    await expect(testRuntime.invokeWorkflow(DebuggerTest, sendUUID).sendWorkflow(recvUUID)).resolves.toBeFalsy(); // return void.
     expect(await handle.getResult()).toBe(true);
     await testRuntime.destroy();
 
     // Execute again in debug mode.
-    await expect(debugRuntime.invoke(DebuggerTest, recvUUID).receiveWorkflow().then((x) => x.getResult())).resolves.toBe(true);
-    await expect(debugRuntime.invoke(DebuggerTest, sendUUID).sendWorkflow(recvUUID, ).then((x) => x.getResult())).resolves.toBeFalsy();
+    await expect(debugRuntime.invokeWorkflow(DebuggerTest, recvUUID).receiveWorkflow()).resolves.toBe(true);
+    await expect(debugRuntime.invokeWorkflow(DebuggerTest, sendUUID).sendWorkflow(recvUUID, )).resolves.toBeFalsy();
   });
 
   test("debug-workflow-events", async() => {
     const getUUID = uuidv1();
     const setUUID = uuidv1();
     // Execute the workflow and destroy the runtime
-    await expect(testRuntime.invoke(DebuggerTest, setUUID).setEventWorkflow().then((x) => x.getResult())).resolves.toBe(0);
-    await expect(testRuntime.invoke(DebuggerTest, getUUID).getEventWorkflow(setUUID, ).then((x) => x.getResult())).resolves.toBe("value1-value2");
+    await expect(testRuntime.invokeWorkflow(DebuggerTest, setUUID).setEventWorkflow()).resolves.toBe(0);
+    await expect(testRuntime.invokeWorkflow(DebuggerTest, getUUID).getEventWorkflow(setUUID, )).resolves.toBe("value1-value2");
     await testRuntime.destroy();
 
     // Execute again in debug mode.
-    await expect(debugRuntime.invoke(DebuggerTest, setUUID).setEventWorkflow().then((x) => x.getResult())).resolves.toBe(0);
-    await expect(debugRuntime.invoke(DebuggerTest, getUUID).getEventWorkflow(setUUID).then((x) => x.getResult())).resolves.toBe("value1-value2");
+    await expect(debugRuntime.invokeWorkflow(DebuggerTest, setUUID).setEventWorkflow()).resolves.toBe(0);
+    await expect(debugRuntime.invokeWorkflow(DebuggerTest, getUUID).getEventWorkflow(setUUID)).resolves.toBe("value1-value2");
   });
 
   test("debug-workflow-input-output", async() => {
     const wfUUID = uuidv1();
     // Execute the workflow and destroy the runtime
-    const res = await testRuntime.invoke(DebuggerTest, wfUUID).diffWorkflow(1)
-      .then((x) => x.getResult());
+    const res = await testRuntime.invokeWorkflow(DebuggerTest, wfUUID).diffWorkflow(1);
     expect(res).toBe(1);
     await testRuntime.destroy();
 

--- a/tests/testing/testing_runtime.test.ts
+++ b/tests/testing/testing_runtime.test.ts
@@ -21,9 +21,8 @@ describe("testruntime-test", () => {
   test("simple-workflow", async () => {
     const uuid = uuidv1();
     const res = await testRuntime
-      .invoke(TestClass, uuid)
-      .testWorkflow(username)
-      .then((x) => x.getResult());
+      .invokeWorkflow(TestClass, uuid)
+      .testWorkflow(username);
     const expectName = testRuntime.getConfig<string>("testvalue"); // Read application config.
     expect(JSON.parse(res)).toEqual({ current_user: expectName });
 


### PR DESCRIPTION
This PR introduces two new methods for invoking workflows from handlers.  For workflow bar in class Foo with argument arg:

- `ctxt.startWorkflow(Foo).bar(arg)` starts the workflow and returns its handle. This is equivalent to the current `ctxt.invoke(Foo).bar(arg)`.
- `ctxt.invokeWorkflow(Foo).bar(arg)` executes the workflow and returns its result. This is equivalent to the current `ctxt.invoke(foo).bar(arg).then((x)=>x.getResult())`.  The latter is very unintuitive and is tripping users up.

To avoid confusion, we also deprecate calling `invoke` on workflows--use one of the new methods instead.

My hope is that this makes it much clearer to users what is actually happening when a handler invokes a workflow.