### PR TITLE
Add support for subscribing to topics by regex

### DIFF
--- a/src/kafka/kafka.ts
+++ b/src/kafka/kafka.ts
@@ -14,7 +14,7 @@ type KafkaArgs = [string, number, KafkaMessage]
 /////////////////////////////
 
 export class KafkaRegistration<This, Args extends unknown[], Return> extends MethodRegistration<This, Args, Return> {
-  kafkaTopic?: string;
+  kafkaTopic?: string | RegExp;
   consumerConfig?: ConsumerConfig;
 
   constructor(origFunc: (this: This, ...args: Args) => Promise<Return>) {
@@ -22,7 +22,7 @@ export class KafkaRegistration<This, Args extends unknown[], Return> extends Met
   }
 }
 
-export function KafkaConsume(topic: string, consumerConfig?: ConsumerConfig) {
+export function KafkaConsume(topic: string | RegExp, consumerConfig?: ConsumerConfig) {
   function kafkadec<This, Ctx extends DBOSContext, Return>(
     target: object,
     propertyKey: string,

--- a/tests/kafka/kafka.test.ts
+++ b/tests/kafka/kafka.test.ts
@@ -144,11 +144,7 @@ class DBOSTestClass {
       txnCounter = txnCounter + 1;
       DBOSTestClass.txnResolve();
     }
-<<<<<<< HEAD
     await DBOSTestClass.txnPromise;
-=======
-    return DBOSTestClass.txnPromise;
->>>>>>> 24a256c (add suport for subscribing to topics by regex)
   }
 
   @KafkaConsume(wfTopic)
@@ -158,22 +154,20 @@ class DBOSTestClass {
       wfCounter = wfCounter + 1;
       DBOSTestClass.wfResolve();
     }
-<<<<<<< HEAD
     await DBOSTestClass.wfPromise;
-=======
-    return DBOSTestClass.wfPromise;
   }
 
   @KafkaConsume(patternTopic)
   @Workflow()
   static async testConsumeTopicsByPattern(_ctxt: WorkflowContext, topic: string, _partition: number, message: KafkaMessage) {
-    if (topic == wfTopic && message.value?.toString() === wfMessage || topic == txnTopic && message.value?.toString() === txnMessage) {
+    const isWfMessage = topic == wfTopic && message.value?.toString() === wfMessage;
+    const isTxnMessage = txnTopic && message.value?.toString() === txnMessage;
+    if ( isWfMessage || isTxnMessage ) {
       patternTopicCounter = patternTopicCounter + 1;
       if (patternTopicCounter === 2) {
         DBOSTestClass.patternTopicResolve();
       }
     }
     return DBOSTestClass.patternTopicPromise;
->>>>>>> 24a256c (add suport for subscribing to topics by regex)
   }
 }

--- a/tests/kafka/kafka.test.ts
+++ b/tests/kafka/kafka.test.ts
@@ -40,7 +40,7 @@ const kafkaConfig: KafkaConfig = {
   logLevel: logLevel.NOTHING, // FOR TESTING
 }
 const kafka = new KafkaJS(kafkaConfig)
-const patternTopic = /dbos-test-.*/;
+const patternTopic = new RegExp(/dbos-test-.*/);
 let patternTopicCounter = 0;
 
 const txnTopic = 'dbos-test-txn-topic';
@@ -168,6 +168,6 @@ class DBOSTestClass {
         DBOSTestClass.patternTopicResolve();
       }
     }
-    return DBOSTestClass.patternTopicPromise;
+    await DBOSTestClass.patternTopicPromise;
   }
 }


### PR DESCRIPTION
kafkajs provides support for it so why not expose it?

This can be extended so as to receive an Array<string | RegExp> instead of just one.
