### PR TITLE
Kafka Retries

### DIFF
--- a/src/kafka/kafka.ts
+++ b/src/kafka/kafka.ts
@@ -66,10 +66,10 @@ export function Kafka(kafkaConfig: KafkaConfig) {
 /* Kafka Management  */
 ///////////////////////
 
-export class DBOSKafka{
+export class DBOSKafka {
   readonly consumers: Consumer[] = [];
 
-  constructor(readonly dbosExec: DBOSExecutor) {}
+  constructor(readonly dbosExec: DBOSExecutor) { }
 
   async initKafka() {
     for (const registeredOperation of this.dbosExec.registeredOperations) {
@@ -83,7 +83,7 @@ export class DBOSKafka{
           throw new DBOSError(`Error registering method ${defaults.name}.${ro.name}: Kafka configuration not found. Does class ${defaults.name} have an @Kafka decorator?`)
         }
         const kafka = new KafkaJS(defaults.kafkaConfig);
-        const consumerConfig = ro.consumerConfig ?? { groupId: `dbos-kafka-group-${ro.kafkaTopic}`}
+        const consumerConfig = ro.consumerConfig ?? { groupId: `dbos-kafka-group-${ro.kafkaTopic}` }
         const consumer = kafka.consumer(consumerConfig);
         await consumer.connect()
         // A temporary workaround for https://github.com/tulios/kafkajs/pull/1558 until it gets fixed
@@ -92,17 +92,17 @@ export class DBOSKafka{
         const maxRetries = 5;
         for (let i = 0; i < maxRetries; i++) {
           try {
-            await consumer.subscribe({topic: ro.kafkaTopic, fromBeginning: true});
+            await consumer.subscribe({ topic: ro.kafkaTopic, fromBeginning: true });
             break;
-            } catch (error) {
-              const e = error as KafkaJSProtocolError;
-              if (e.code === 3 && i + 1 < maxRetries) { //UNKNOWN_TOPIC_OR_PARTITION
-                await sleep(1000);
-                continue;
-              } else {
-                throw e
-              }
+          } catch (error) {
+            const e = error as KafkaJSProtocolError;
+            if (e.code === 3 && i + 1 < maxRetries) { // UNKNOWN_TOPIC_OR_PARTITION
+              await sleep(1000);
+              continue;
+            } else {
+              throw e
             }
+          }
         }
         await consumer.run({
           eachMessage: async ({ topic, partition, message }) => {

--- a/tests/kafka/kafka.test.ts
+++ b/tests/kafka/kafka.test.ts
@@ -12,31 +12,22 @@ import { Knex } from "knex";
 
 `
 version: "3.7"
-
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper:latest
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-    ports:
-      - 2181:2181
-
-  kafka:
-    image: confluentinc/cp-kafka:latest
-    depends_on:
-      - zookeeper
-    ports:
-      - 9092:9092
-    environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
-      KAFKA_LISTENERS: PLAINTEXT://:9092
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+  broker:
+      image: public.ecr.aws/bitnami/kafka:3.6.2-debian-12-r3
+      hostname: broker
+      container_name: broker
+      ports:
+        - '9092:9092'
+      environment:
+        KAFKA_CFG_NODE_ID: 1
+        KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'
+        KAFKA_CFG_ADVERTISED_LISTENERS: 'PLAINTEXT_HOST://localhost:9092,PLAINTEXT://broker:19092'
+        KAFKA_CFG_PROCESS_ROLES: 'broker,controller'
+        KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: '1@broker:29093'
+        KAFKA_CFG_LISTENERS: 'CONTROLLER://:29093,PLAINTEXT_HOST://:9092,PLAINTEXT://:19092'
+        KAFKA_CFG_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+        KAFKA_CFG_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
 `
 
 const kafkaConfig: KafkaConfig = {

--- a/tests/kafka/kafka.test.ts
+++ b/tests/kafka/kafka.test.ts
@@ -14,7 +14,7 @@ import { Knex } from "knex";
 version: "3.7"
 services:
   broker:
-      image: public.ecr.aws/bitnami/kafka:3.6.2-debian-12-r3
+      image: bitnami/kafka:latest
       hostname: broker
       container_name: broker
       ports:


### PR DESCRIPTION
This PR is a temporary workaround for https://github.com/tulios/kafkajs/pull/1558 until it gets fixed. If topic autocreation is on and you try to subscribe to a nonexistent topic, KafkaJS should retry until the topic is created. However, curently KafkaJS does not retry, so Transact will instead.