### PR TITLE
Make logging consistent in migration.ts

### DIFF
--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -104,7 +104,7 @@ if (!process.argv.slice(2).length) {
 //If otel exporter is specified in configFile, adds it to the logger and flushes it after.
 //If action throws, logs the exception and sets the exit code to 1.
 //Finally, terminates the program with the exit code.
-export async function runAndLog(action: (configFile: ConfigFile, logger: GlobalLogger) => Promise<number>) {
+export async function runAndLog(action: (configFile: ConfigFile, logger: GlobalLogger) => Promise<number> | number) {
   let logger = new GlobalLogger();
   const configFile: ConfigFile | undefined = loadConfigFile(dbosConfigFilePath);
   if (!configFile) {

--- a/src/dbos-runtime/migrate.ts
+++ b/src/dbos-runtime/migrate.ts
@@ -162,9 +162,9 @@ async function createDBOSTables(configFile: ConfigFile) {
   }
 }
 
-type SpawnSyncError<T> = Error & SpawnSyncReturns<T>;
+type ExecSyncError<T> = Error & SpawnSyncReturns<T>;
 
-function isExecSyncError(e: Error): e is SpawnSyncError<string | Buffer> {
+function isExecSyncError(e: Error): e is ExecSyncError<string | Buffer> {
   if (
     //Safeguard against NaN. NaN type is number but NaN !== NaN
     "pid" in e && (typeof e.pid === 'number' && e.pid === e.pid) &&
@@ -176,7 +176,7 @@ function isExecSyncError(e: Error): e is SpawnSyncError<string | Buffer> {
   return false
 }
 
-function logMigrationError(e: SpawnSyncError<string | Buffer>, logger: GlobalLogger) {
+function logMigrationError(e: ExecSyncError<string | Buffer>, logger: GlobalLogger) {
   const stderr = e.stderr;
   if (e.stderr.length > 0) {
     logger.error(`Standard Error: ${stderr.toString().trim()}`);

--- a/src/dbos-runtime/migrate.ts
+++ b/src/dbos-runtime/migrate.ts
@@ -43,7 +43,7 @@ export async function migrate(configFile: ConfigFile, logger: GlobalLogger) {
   try {
     migrationCommands?.forEach((cmd) => {
       logger.info(`Executing migration command: ${cmd}`);
-      const migrateCommandOutput = execSync(cmd, {encoding: 'utf8'});
+      const migrateCommandOutput = execSync(cmd, {encoding: 'utf-8'});
       logger.info(migrateCommandOutput.trimEnd());
     });
   } catch (e) {

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -9,7 +9,6 @@ import { DBOSContext, DBOSContextImpl, InitContext } from "./context";
 import { CommunicatorConfig, CommunicatorContext } from "./communicator";
 import { DBOSNotAuthorizedError } from "./error";
 import { validateMethodArgs } from "./data_validation";
-import { UserDatabaseClient } from "./user_database";
 
 /**
  * Any column type column can be.
@@ -491,11 +490,12 @@ export function Workflow(config: WorkflowConfig={}) {
   return decorator;
 }
 
-export function Transaction<T extends UserDatabaseClient>(config: TransactionConfig={}) {
+export function Transaction(config: TransactionConfig={}) {
   function decorator<This, Args extends unknown[], Return>(
     target: object,
     propertyKey: string,
-    inDescriptor: TypedPropertyDescriptor<(this: This, ctx: TransactionContext<T>, ...args: Args) => Promise<Return>>)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    inDescriptor: TypedPropertyDescriptor<(this: This, ctx: TransactionContext<any>, ...args: Args) => Promise<Return>>)
   {
     const { descriptor, registration } = registerAndWrapFunction(target, propertyKey, inDescriptor);
     registration.txnConfig = config;

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -9,6 +9,7 @@ import { DBOSContext, DBOSContextImpl, InitContext } from "./context";
 import { CommunicatorConfig, CommunicatorContext } from "./communicator";
 import { DBOSNotAuthorizedError } from "./error";
 import { validateMethodArgs } from "./data_validation";
+import { UserDatabaseClient } from "./user_database";
 
 /**
  * Any column type column can be.
@@ -490,12 +491,11 @@ export function Workflow(config: WorkflowConfig={}) {
   return decorator;
 }
 
-export function Transaction(config: TransactionConfig={}) {
+export function Transaction<T extends UserDatabaseClient>(config: TransactionConfig={}) {
   function decorator<This, Args extends unknown[], Return>(
     target: object,
     propertyKey: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    inDescriptor: TypedPropertyDescriptor<(this: This, ctx: TransactionContext<any>, ...args: Args) => Promise<Return>>)
+    inDescriptor: TypedPropertyDescriptor<(this: This, ctx: TransactionContext<T>, ...args: Args) => Promise<Return>>)
   {
     const { descriptor, registration } = registerAndWrapFunction(target, propertyKey, inDescriptor);
     registration.txnConfig = config;
@@ -533,7 +533,6 @@ export function DBOSInitializer() {
   function decorator<This, Args extends unknown[], Return>(
     target: object,
     propertyKey: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     inDescriptor: TypedPropertyDescriptor<(this: This, ctx: InitContext, ...args: Args) => Promise<Return>>)
   {
     const { descriptor, registration } = registerAndWrapFunction(target, propertyKey, inDescriptor);
@@ -548,7 +547,6 @@ export function DBOSDeploy() {
   function decorator<This, Args extends unknown[], Return>(
     target: object,
     propertyKey: string,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     inDescriptor: TypedPropertyDescriptor<(this: This, ctx: InitContext, ...args: Args) => Promise<Return>>)
   {
     const { descriptor, registration } = registerAndWrapFunction(target, propertyKey, inDescriptor);

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -2,20 +2,16 @@ import { LoggerConfig } from "./logs";
 import { OTLPExporterConfig } from "./exporters";
 import { Span } from "@opentelemetry/sdk-trace-base";
 import { LogRecord } from "@opentelemetry/api-logs";
+import { TelemetrySignal } from "./collector";
 
-// We could implement our own types and avoid having `any`, but this has likely little value
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isTraceSignal(signal: any): signal is Span {
+export function isTraceSignal(signal: TelemetrySignal): signal is Span {
   // Span is an interface that has a property 'kind'
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  return signal && 'kind' in signal;
+  return 'kind' in signal;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isLogSignal(signal: any): signal is LogRecord {
+export function isLogSignal(signal: TelemetrySignal): signal is LogRecord {
   // LogRecord is an interface that has a property 'severityText' and 'severityNumber'
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-  return signal && 'severityText' in signal && 'severityNumber' in signal;
+  return 'severityText' in signal && 'severityNumber' in signal;
 }
 
 export interface TelemetryConfig {

--- a/src/telemetry/logs.ts
+++ b/src/telemetry/logs.ts
@@ -55,8 +55,7 @@ export class GlobalLogger {
   }
 
   // We use this form of winston logging methods: `(message: string, ...meta: any[])`. See node_modules/winston/index.d.ts
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  info(logEntry: any, metadata?: ContextualMetadata): void {
+  info(logEntry: unknown, metadata?: ContextualMetadata): void {
     if (typeof logEntry === "string") {
       this.logger.info(logEntry, metadata);
     } else {
@@ -64,8 +63,7 @@ export class GlobalLogger {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  debug(logEntry: any, metadata?: ContextualMetadata): void {
+  debug(logEntry: unknown, metadata?: ContextualMetadata): void {
     if (typeof logEntry === "string") {
       this.logger.debug(logEntry, metadata);
     } else {
@@ -73,8 +71,7 @@ export class GlobalLogger {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  warn(logEntry: any, metadata?: ContextualMetadata): void {
+  warn(logEntry: unknown, metadata?: ContextualMetadata): void {
     if (typeof logEntry === "string") {
       this.logger.warn(logEntry, metadata);
     } else {
@@ -83,8 +80,7 @@ export class GlobalLogger {
   }
 
   // metadata can have both ContextualMetadata and the error stack trace
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  error(inputError: any, metadata?: ContextualMetadata & StackTrace): void {
+  error(inputError: unknown, metadata?: ContextualMetadata & StackTrace): void {
     if (inputError instanceof Error) {
       this.logger.error(inputError.message, { ...metadata, stack: inputError.stack });
     } else if (typeof inputError === "string") {
@@ -113,23 +109,19 @@ export class Logger {
     };
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  info(logEntry: any): void {
+  info(logEntry: unknown): void {
     this.globalLogger.info(logEntry, this.metadata);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  debug(logEntry: any): void {
+  debug(logEntry: unknown): void {
     this.globalLogger.debug(logEntry, this.metadata);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  warn(logEntry: any): void {
+  warn(logEntry: unknown): void {
     this.globalLogger.warn(logEntry, this.metadata);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  error(inputError: any): void {
+  error(inputError: unknown): void {
     this.globalLogger.error(inputError, this.metadata);
   }
 }


### PR DESCRIPTION
This PR makes logging of execSync errors typed and consistent in migration.ts.
It also removes some //eslint-disable from telemetry
