### PR TITLE
Allow app to register/deploy under a different name

### DIFF
--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -55,7 +55,7 @@ async function createZipData(logger: CLILogger): Promise<string> {
     return buffer.toString('base64');
 }
 
-export async function deployAppCode(host: string, rollback: boolean, previousVersion: string | null, verbose: boolean, targetDatabaseName: string | null = null): Promise<number> {
+export async function deployAppCode(host: string, rollback: boolean, previousVersion: string | null, verbose: boolean, targetDatabaseName: string | null = null, appName: string | undefined): Promise<number> {
   const logger = getLogger(verbose);
   logger.debug("Getting cloud credentials...");
   const userCredentials = await getCloudCredentials();
@@ -63,7 +63,7 @@ export async function deployAppCode(host: string, rollback: boolean, previousVer
   logger.debug("  ... got cloud credentials");
 
   logger.debug("Retrieving app name...");
-  const appName = retrieveApplicationName(logger);
+  appName = appName || retrieveApplicationName(logger);
   if (!appName) {
     logger.error("Failed to get app name.");
     return 1;

--- a/packages/dbos-cloud/applications/get-app-logs.ts
+++ b/packages/dbos-cloud/applications/get-app-logs.ts
@@ -8,7 +8,7 @@ type LogResponse = {
 };
 
 
-export async function getAppLogs(host: string, last: number, pagesize:number): Promise<number> {
+export async function getAppLogs(host: string, last: number, pagesize:number, appName: string | undefined): Promise<number> {
   if (last != undefined && (isNaN(last) || last <= 0)) {
     throw new Error('The --last parmameter must be an integer greater than 0');
   }
@@ -26,7 +26,11 @@ export async function getAppLogs(host: string, last: number, pagesize:number): P
   const logger = getLogger();
   const userCredentials = await getCloudCredentials();
   const bearerToken = "Bearer " + userCredentials.token;
-  const appName = retrieveApplicationName(logger);
+  appName = appName || retrieveApplicationName(logger);
+  if (!appName) {
+    return 1;
+  }
+
   const url = `https://${host}/v1alpha1/${userCredentials.userName}/logs/applications/${appName}`;
   const headers = {
     "Content-Type": "application/json",
@@ -36,9 +40,6 @@ export async function getAppLogs(host: string, last: number, pagesize:number): P
     last: last,
     limit: pagesize,
     format: 'json'
-  }
-  if (!appName) {
-    return 1;
   }
   try {
     const res = await axios.get(url, {headers: headers, params: params});

--- a/packages/dbos-cloud/applications/register-app.ts
+++ b/packages/dbos-cloud/applications/register-app.ts
@@ -2,12 +2,12 @@ import axios, { AxiosError } from "axios";
 import { handleAPIErrors, getCloudCredentials, getLogger, isCloudAPIErrorResponse, retrieveApplicationName, CloudAPIErrorResponse } from "../cloudutils.js";
 import chalk from 'chalk';
 
-export async function registerApp(dbname: string, host: string): Promise<number> {
+export async function registerApp(dbname: string, host: string, appName?: string): Promise<number> {
   const logger = getLogger();
   const userCredentials = await getCloudCredentials();
   const bearerToken = "Bearer " + userCredentials.token;
 
-  const appName = retrieveApplicationName(logger);
+  appName = appName || retrieveApplicationName(logger);
   if (!appName) {
     return 1;
   }

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -120,45 +120,49 @@ const applicationCommands = program
 applicationCommands
   .command('register')
   .description('Register this application')
+  .argument('[string]', 'application name (Default: name from package.json)')
   .requiredOption('-d, --database <string>', 'Specify a Postgres database instance for this application')
-  .action(async (options: { database: string }) => {
-    const exitCode = await registerApp(options.database, DBOSCloudHost);
+  .action(async (appName: string | undefined, options: { database: string }) => {
+    const exitCode = await registerApp(options.database, DBOSCloudHost, appName);
     process.exit(exitCode);
   });
 
 applicationCommands
   .command('deploy')
   .description('Deploy this application to the cloud and run associated database migration commands')
+  .argument('[string]', 'application name (Default: name from package.json)')
   .option('--verbose', 'Verbose log of deployment step')
   .option('-p, --previous-version <string>', 'Specify a previous version to restore')
-  .action(async (options: {verbose?: boolean, previousVersion?: string}) => {
-    const exitCode = await deployAppCode(DBOSCloudHost, false, options.previousVersion ?? null, options.verbose ?? false);
+  .action(async (appName: string | undefined, options: {verbose?: boolean, previousVersion?: string}) => {
+    const exitCode = await deployAppCode(DBOSCloudHost, false, options.previousVersion ?? null, options.verbose ?? false, null, appName);
     process.exit(exitCode);
   });
 
 applicationCommands
   .command('rollback')
   .description('Deploy this application to the cloud and run associated database rollback commands')
-  .action(async () => {
-    const exitCode = await deployAppCode(DBOSCloudHost, true, null, false);
+  .argument('[string]', 'application name (Default: name from package.json)')
+  .action(async (appName: string | undefined) => {
+    const exitCode = await deployAppCode(DBOSCloudHost, true, null, false, null, appName);
     process.exit(exitCode);
   });
 
 applicationCommands
   .command('change-database-instance')
   .description('Change this application\'s database instance and redeploy it')
+  .argument('[string]', 'application name (Default: name from package.json)')
   .option('--verbose', 'Verbose log of deployment step')
   .option('-p, --previous-version <string>', 'Specify a previous version to restore')
   .requiredOption('-d, --database <string>', 'Specify the new database instance name for this application')
-  .action(async (options: {verbose?: boolean, previousVersion?: string, database: string}) => {
-    const exitCode = await deployAppCode(DBOSCloudHost, false, options.previousVersion ?? null, options.verbose ?? false, options.database);
+  .action(async (appName: string | undefined, options: {verbose?: boolean, previousVersion?: string, database: string}) => {
+    const exitCode = await deployAppCode(DBOSCloudHost, false, options.previousVersion ?? null, options.verbose ?? false, options.database, appName);
     process.exit(exitCode);
   });
 
 applicationCommands
   .command('delete')
   .description('Delete this application')
-  .argument('[string]', 'application name')
+  .argument('[string]', 'application name (Default: name from package.json)')
   .option('--dropdb', 'Drop application database')
   .action(async (appName: string | undefined, options: { dropdb: boolean }) => {
     const exitCode = await deleteApp(DBOSCloudHost, options.dropdb, appName);
@@ -177,7 +181,7 @@ applicationCommands
 applicationCommands
   .command('status')
   .description("Retrieve this application's status")
-  .argument('[string]', 'application name')
+  .argument('[string]', 'application name (Default: name from package.json)')
   .option('--json', 'Emit JSON output')
   .action(async (appName: string | undefined, options: { json: boolean }) => {
     const exitCode = await getAppInfo(DBOSCloudHost, options.json, appName);
@@ -187,7 +191,7 @@ applicationCommands
 applicationCommands
   .command('versions')
   .description("Retrieve a list of an application's versions")
-  .argument('[string]', 'application name')
+  .argument('[string]', 'application name (Default: name from package.json)')
   .option('--json', 'Emit JSON output')
   .action(async (appName: string | undefined, options: { json: boolean }) => {
     const exitCode = await listAppVersions(DBOSCloudHost, options.json, appName);
@@ -197,10 +201,11 @@ applicationCommands
 applicationCommands
   .command('logs')
   .description("Print this application's logs")
+  .argument('[string]', 'application name (Default: name from package.json)')
   .option('-l, --last <integer>', 'How far back to query, in seconds from current time. By default, we retrieve all data', parseInt)
   .option('-p, --pagesize <integer>', 'How many lines to fetch at once when paginating. Default is 1000', parseInt)
-  .action(async (options: { last: number, pagesize: number}) => {
-    const exitCode = await getAppLogs(DBOSCloudHost, options.last, options.pagesize);
+  .action(async (appName: string | undefined, options: { last: number, pagesize: number}) => {
+    const exitCode = await getAppLogs(DBOSCloudHost, options.last, options.pagesize, appName);
     process.exit(exitCode);
   });
 


### PR DESCRIPTION
This is useful if we want to deploy the same code to two different apps, for example for staging vs prod deployments we can have `app-staging` vs `app-prod`.

This PR also makes it possible to retrieve logs for other apps.