### PR TITLE
add the  --report-unused-disable-directives to lint script

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-.eslintrc.cjs

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+.eslintrc.cjs

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "npm run --workspaces build && tsc --project tsconfig.build.json",
     "build-fdb": "npm run --workspaces build && tsc --project tsconfig.build-fdb.json",
-    "lint": "eslint --fix --ext .ts --ignore-pattern foundationdb/ --ignore-pattern templates/ .",
+    "lint": "eslint --fix --ext .ts --report-unused-disable-directives --ignore-pattern foundationdb/ --ignore-pattern templates/ .",
     "lint-fdb": "eslint --fix --ext .ts --ignore-pattern templates/ .",
     "setversion": "npm run --workspaces setversion && grunt setversion",
     "test": "npm run build && npm run --workspaces test && npx prisma generate --schema tests/prisma/schema.prisma && jest --coverage --collectCoverageFrom='src/**/*' --collectCoverageFrom='!src/foundationdb/**/*' --detectOpenHandles --testPathIgnorePatterns=examples/* --testPathIgnorePatterns=packages/* --testPathIgnorePatterns=tests/foundationdb/*",

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -224,7 +224,7 @@ export class DBOSExecutor {
             username: userDBConfig.user,
             password: userDBConfig.password,
             database: userDBConfig.database,
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+             
             entities: this.entities,
             ssl: userDBConfig.ssl,
           })

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -224,7 +224,6 @@ export class DBOSExecutor {
             username: userDBConfig.user,
             password: userDBConfig.password,
             database: userDBConfig.database,
-             
             entities: this.entities,
             ssl: userDBConfig.ssl,
           })

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,5 +1,3 @@
-
-
 import "reflect-metadata";
 
 import * as crypto from "crypto";

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
+
 
 import "reflect-metadata";
 

--- a/src/httpServer/handler.ts
+++ b/src/httpServer/handler.ts
@@ -78,9 +78,9 @@ export class HandlerContextImpl extends DBOSContextImpl implements HandlerContex
     this.request = {
       headers: koaContext.request.headers,
       rawHeaders: koaContext.req.rawHeaders,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+       
       params: koaContext.params,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+       
       body: koaContext.request.body,
       rawBody: koaContext.request.rawBody,
       query: koaContext.request.query,

--- a/src/httpServer/handler.ts
+++ b/src/httpServer/handler.ts
@@ -78,9 +78,7 @@ export class HandlerContextImpl extends DBOSContextImpl implements HandlerContex
     this.request = {
       headers: koaContext.request.headers,
       rawHeaders: koaContext.req.rawHeaders,
-       
       params: koaContext.params,
-       
       body: koaContext.request.body,
       rawBody: koaContext.request.rawBody,
       query: koaContext.request.query,

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -137,7 +137,7 @@ async checkPortAvailability(port: number, host: string): Promise<void> {
   static registerRecoveryEndpoint(dbosExec: DBOSExecutor, router: Router) {
     // Handler function that parses request for recovery.
     const recoveryHandler = async (koaCtxt: Koa.Context, koaNext: Koa.Next) => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+       
       const executorIDs = koaCtxt.request.body as string[];
       dbosExec.logger.info("Recovering workflows for executors: " + executorIDs.toString());
       const recoverHandles = await dbosExec.recoverPendingWorkflows(executorIDs);

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -137,7 +137,6 @@ async checkPortAvailability(port: number, host: string): Promise<void> {
   static registerRecoveryEndpoint(dbosExec: DBOSExecutor, router: Router) {
     // Handler function that parses request for recovery.
     const recoveryHandler = async (koaCtxt: Koa.Context, koaNext: Koa.Next) => {
-       
       const executorIDs = koaCtxt.request.body as string[];
       dbosExec.logger.info("Recovering workflows for executors: " + executorIDs.toString());
       const recoverHandles = await dbosExec.recoverPendingWorkflows(executorIDs);

--- a/src/telemetry/logs.ts
+++ b/src/telemetry/logs.ts
@@ -147,7 +147,6 @@ const consoleFormat = format.combine(
     const fullMessageString = `${messageString}${info.includeContextMetadata ? ` ${JSON.stringify((info.span as Span)?.attributes)}` : ""}`;
 
     const versionString = applicationVersion ? ` [version ${applicationVersion}]` : "";
-     
     return `${ts}${versionString} [${level}]: ${fullMessageString} ${stack ? "\n" + formattedStack : ""}`;
   })
 );
@@ -214,8 +213,6 @@ class OTLPLogQueueTransport extends TransportStream {
         applicationID: this.applicationID,
         executorID: this.executorID,
       } as LogAttributes,
-       
-      // context: span?.spanContext() || undefined,
     });
 
     callback();

--- a/src/telemetry/logs.ts
+++ b/src/telemetry/logs.ts
@@ -147,7 +147,7 @@ const consoleFormat = format.combine(
     const fullMessageString = `${messageString}${info.includeContextMetadata ? ` ${JSON.stringify((info.span as Span)?.attributes)}` : ""}`;
 
     const versionString = applicationVersion ? ` [version ${applicationVersion}]` : "";
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+     
     return `${ts}${versionString} [${level}]: ${fullMessageString} ${stack ? "\n" + formattedStack : ""}`;
   })
 );
@@ -214,7 +214,7 @@ class OTLPLogQueueTransport extends TransportStream {
         applicationID: this.applicationID,
         executorID: this.executorID,
       } as LogAttributes,
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+       
       // context: span?.spanContext() || undefined,
     });
 

--- a/src/user_database.ts
+++ b/src/user_database.ts
@@ -212,13 +212,11 @@ export class PrismaUserDatabase implements UserDatabase {
   }
 
   async query<R, T extends unknown[]>(sql: string, ...params: T): Promise<R[]> {
-     
     return this.prisma.$queryRawUnsafe<R, T>(sql, ...params);
   }
 
   async queryWithClient<R, T extends unknown[]>(client: UserDatabaseClient, sql: string, ...params: T): Promise<R[]> {
     const prismaClient = client as PrismaClient;
-     
     return prismaClient.$queryRawUnsafe<R, T>(sql, ...params);
   }
 
@@ -406,7 +404,6 @@ export class KnexUserDatabase implements UserDatabase {
   }
 
   async query<R, T extends unknown[]>(sql: string, ...params: T): Promise<R[]> {
-     
     return this.queryWithClient(this.knex, sql, ...params);
   }
 

--- a/src/user_database.ts
+++ b/src/user_database.ts
@@ -212,13 +212,13 @@ export class PrismaUserDatabase implements UserDatabase {
   }
 
   async query<R, T extends unknown[]>(sql: string, ...params: T): Promise<R[]> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+     
     return this.prisma.$queryRawUnsafe<R, T>(sql, ...params);
   }
 
   async queryWithClient<R, T extends unknown[]>(client: UserDatabaseClient, sql: string, ...params: T): Promise<R[]> {
     const prismaClient = client as PrismaClient;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+     
     return prismaClient.$queryRawUnsafe<R, T>(sql, ...params);
   }
 
@@ -406,7 +406,7 @@ export class KnexUserDatabase implements UserDatabase {
   }
 
   async query<R, T extends unknown[]>(sql: string, ...params: T): Promise<R[]> {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+     
     return this.queryWithClient(this.knex, sql, ...params);
   }
 

--- a/tests/dbos-runtime/runtime.test.ts
+++ b/tests/dbos-runtime/runtime.test.ts
@@ -1,5 +1,3 @@
- 
- 
 import axios, { AxiosError } from "axios";
 import { spawn, execSync, ChildProcess } from "child_process";
 import { Writable } from "stream";

--- a/tests/dbos-runtime/runtime.test.ts
+++ b/tests/dbos-runtime/runtime.test.ts
@@ -1,5 +1,5 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+ 
+ 
 import axios, { AxiosError } from "axios";
 import { spawn, execSync, ChildProcess } from "child_process";
 import { Writable } from "stream";

--- a/tests/httpServer/cors.test.ts
+++ b/tests/httpServer/cors.test.ts
@@ -1,4 +1,3 @@
- 
 import {
   GetApi,
 } from "../../src";

--- a/tests/httpServer/cors.test.ts
+++ b/tests/httpServer/cors.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+ 
 import {
   GetApi,
 } from "../../src";

--- a/tests/httpServer/validation.test.ts
+++ b/tests/httpServer/validation.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+ 
 import { GetApi, PostApi, ArgVarchar, ArgDate, DefaultArgRequired, DefaultArgOptional, ArgRequired, ArgOptional, TestingRuntime, Workflow } from "../../src";
 import { generateDBOSTestConfig, setUpDBOSTestDb } from "../helpers";
 import request from "supertest";

--- a/tests/httpServer/validation.test.ts
+++ b/tests/httpServer/validation.test.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
- 
 import { GetApi, PostApi, ArgVarchar, ArgDate, DefaultArgRequired, DefaultArgOptional, ArgRequired, ArgOptional, TestingRuntime, Workflow } from "../../src";
 import { generateDBOSTestConfig, setUpDBOSTestDb } from "../helpers";
 import request from "supertest";

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -83,9 +83,7 @@ describe("dbos-telemetry", () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(response.body.message).toBe("hello!");
       // traceId should be the same, spanId should be different (ID of the last operation's span)
-       
       expect(response.headers.traceparent).toContain("00-4bf92f3577b34da6a3ce929d0e0e4736");
-       
       expect(response.headers.tracestate).toBe(headers[TRACE_STATE_HEADER]);
     });
 
@@ -95,7 +93,6 @@ describe("dbos-telemetry", () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(response.body.message).toBe("hello!");
       // traceId should be the same, spanId should be different (ID of the last operation's span)
-       
       expect(response.headers.traceparent).not.toBe(null);
     });
   });

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -83,9 +83,9 @@ describe("dbos-telemetry", () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(response.body.message).toBe("hello!");
       // traceId should be the same, spanId should be different (ID of the last operation's span)
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+       
       expect(response.headers.traceparent).toContain("00-4bf92f3577b34da6a3ce929d0e0e4736");
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+       
       expect(response.headers.tracestate).toBe(headers[TRACE_STATE_HEADER]);
     });
 
@@ -95,7 +95,7 @@ describe("dbos-telemetry", () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       expect(response.body.message).toBe("hello!");
       // traceId should be the same, spanId should be different (ID of the last operation's span)
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+       
       expect(response.headers.traceparent).not.toBe(null);
     });
   });


### PR DESCRIPTION
This PR adds the --report-unused-disable-directives which removes all unused eslint disable directives.

It also adds a .eslintignore file that excludes the `.eslintrc.cjs` file.
This is because after enabling the Microsoft eslint plugin in VSCode it  complains about [this](https://typescript-eslint.io/troubleshooting/#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file)
Many ways to solve it and I picked the easiest one.
Really why the `.cjs` extension? why not `.js` or '.json' ?
