### PR TITLE
Update typescript and ts-json-schema-generator 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "supertest": "^7.0.0",
         "ts-jest": "^29.1.2",
         "typeorm": "^0.3.17",
-        "typescript": "5.3.3"
+        "typescript": "5.4.5"
       },
       "optionalDependencies": {
         "foundationdb": "^2.0.1"
@@ -9345,31 +9345,23 @@
       }
     },
     "node_modules/ts-json-schema-generator": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/ts-json-schema-generator/-/ts-json-schema-generator-1.5.0.tgz",
-      "integrity": "sha512-RkiaJ6YxGc5EWVPfyHxszTmpGxX8HC2XBvcFlAl1zcvpOG4tjjh+eXioStXJQYTvr9MoK8zCOWzAUlko3K0DiA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ts-json-schema-generator/-/ts-json-schema-generator-1.5.1.tgz",
+      "integrity": "sha512-apX5qG2+NA66j7b4AJm8q/DpdTeOsjfh7A3LpKsUiil0FepkNwtN28zYgjrsiiya2/OPhsr/PSjX5FUYg79rCg==",
       "dependencies": {
-        "@types/json-schema": "^7.0.12",
-        "commander": "^11.0.0",
+        "@types/json-schema": "^7.0.15",
+        "commander": "^12.0.0",
         "glob": "^8.0.3",
         "json5": "^2.2.3",
         "normalize-path": "^3.0.0",
         "safe-stable-stringify": "^2.4.3",
-        "typescript": "~5.3.2"
+        "typescript": "~5.4.2"
       },
       "bin": {
         "ts-json-schema-generator": "bin/ts-json-schema-generator"
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/ts-json-schema-generator/node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/ts-json-schema-generator/node_modules/glob": {
@@ -9595,9 +9587,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10070,7 +10062,7 @@
         "@types/bcryptjs": "^2.4.6",
         "grunt": "^1.6.1",
         "nerdbank-gitversioning": "^3.6.133",
-        "typescript": "^5.3.3"
+        "typescript": "5.4.5"
       },
       "peerDependencies": {
         "@dbos-inc/dbos-sdk": "*"
@@ -10083,7 +10075,7 @@
       "devDependencies": {
         "grunt": "^1.6.1",
         "nerdbank-gitversioning": "^3.6.133",
-        "typescript": "^5.3.3"
+        "typescript": "^5.4.5"
       },
       "peerDependencies": {
         "@dbos-inc/dbos-sdk": "*"
@@ -10096,7 +10088,7 @@
       "devDependencies": {
         "grunt": "^1.6.1",
         "nerdbank-gitversioning": "^3.6.133",
-        "typescript": "^5.3.3"
+        "typescript": "^5.4.5"
       },
       "peerDependencies": {
         "@dbos-inc/dbos-sdk": "*"
@@ -10130,7 +10122,7 @@
         "@types/validator": "^13.11.9",
         "grunt": "^1.6.1",
         "nerdbank-gitversioning": "^3.6.133",
-        "typescript": "^5.3.3"
+        "typescript": "^5.4.5"
       }
     },
     "packages/create/node_modules/@types/inquirer": {
@@ -10245,7 +10237,7 @@
         "@types/validator": "^13.11.9",
         "grunt": "^1.6.1",
         "nerdbank-gitversioning": "^3.6.133",
-        "typescript": "^5.3.3"
+        "typescript": "^5.4.5"
       }
     },
     "packages/dbos-openapi": {
@@ -10255,8 +10247,8 @@
       "dependencies": {
         "commander": "^11.0.0",
         "openapi-types": "^12.1.3",
-        "ts-json-schema-generator": "^1.5.0",
-        "typescript": "5.3.3",
+        "ts-json-schema-generator": "^1.5.1",
+        "typescript": "5.4.5",
         "yaml": "^2.3.4"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "supertest": "^7.0.0",
         "ts-jest": "^29.1.2",
         "typeorm": "^0.3.17",
-        "typescript": "5.4.5"
+        "typescript": "^5.4.5"
       },
       "optionalDependencies": {
         "foundationdb": "^2.0.1"
@@ -716,10 +716,13 @@
       "link": true
     },
     "node_modules/@dbos-inc/dbos-sdk": {
-      "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@dbos-inc/dbos-sdk/-/dbos-sdk-1.2.12.tgz",
-      "integrity": "sha512-fd9l7OKy9qGzmgCZtoV+r0ppspqFToKXXWzKPQt5KDGyaBZhRytekhvARVhajzNNo4ZeyvItnZ0ts0+ZE0sniA==",
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@dbos-inc/dbos-sdk/-/dbos-sdk-1.10.7.tgz",
+      "integrity": "sha512-A+apDghyOkOKHBnqUfHMCtoNEPHkv5B4uFiMHyG4FmF5uDOyeLdQChgmyaBI/jgAZNTBedFvRuU56uTdWqBWyQ==",
       "peer": true,
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@koa/bodyparser": "5.0.0",
         "@koa/cors": "5.0.0",
@@ -733,18 +736,19 @@
         "@opentelemetry/sdk-logs": "0.49.1",
         "@opentelemetry/sdk-trace-base": "1.22.0",
         "@opentelemetry/semantic-conventions": "1.22.0",
+        "ajv": "8.13.0",
         "axios": "1.6.7",
         "commander": "12.0.0",
-        "fast-glob": "3.3.2",
+        "inquirer": "^8.2.6",
+        "kafkajs": "^2.2.4",
         "knex": "3.1.0",
         "koa": "2.15.0",
         "lodash": "4.17.21",
         "openapi-types": "12.1.3",
         "pg": "8.11.3",
-        "reflect-metadata": "0.2.1",
+        "reflect-metadata": "0.2.2",
         "serialize-error": "8.1.0",
         "uuid": "9.0.1",
-        "validator": "13.11.0",
         "winston": "3.12.0",
         "winston-transport": "4.7.0",
         "yaml": "2.4.1"
@@ -756,13 +760,6 @@
       "optionalDependencies": {
         "foundationdb": "^2.0.1"
       }
-    },
-    "node_modules/@dbos-inc/dbos-sdk/node_modules/reflect-metadata": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.1.tgz",
-      "integrity": "sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw==",
-      "deprecated": "This version has a critical bug in fallback handling. Please upgrade to reflect-metadata@0.2.2 or newer.",
-      "peer": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -10062,7 +10059,7 @@
         "@types/bcryptjs": "^2.4.6",
         "grunt": "^1.6.1",
         "nerdbank-gitversioning": "^3.6.133",
-        "typescript": "5.4.5"
+        "typescript": "^5.4.5"
       },
       "peerDependencies": {
         "@dbos-inc/dbos-sdk": "*"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "supertest": "^7.0.0",
     "ts-jest": "^29.1.2",
     "typeorm": "^0.3.17",
-    "typescript": "5.3.3"
+    "typescript": "5.4.5"
   },
   "dependencies": {
     "@koa/bodyparser": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "supertest": "^7.0.0",
     "ts-jest": "^29.1.2",
     "typeorm": "^0.3.17",
-    "typescript": "5.4.5"
+    "typescript": "^5.4.5"
   },
   "dependencies": {
     "@koa/bodyparser": "5.0.0",

--- a/packages/communicator-bcrypt/package.json
+++ b/packages/communicator-bcrypt/package.json
@@ -20,7 +20,7 @@
     "@types/bcryptjs": "^2.4.6",
     "grunt": "^1.6.1",
     "nerdbank-gitversioning": "^3.6.133",
-    "typescript": "^5.3.3"
+    "typescript": "5.4.5"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3"

--- a/packages/communicator-bcrypt/package.json
+++ b/packages/communicator-bcrypt/package.json
@@ -20,7 +20,7 @@
     "@types/bcryptjs": "^2.4.6",
     "grunt": "^1.6.1",
     "nerdbank-gitversioning": "^3.6.133",
-    "typescript": "5.4.5"
+    "typescript": "^5.4.5"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3"

--- a/packages/communicator-datetime/package.json
+++ b/packages/communicator-datetime/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "grunt": "^1.6.1",
     "nerdbank-gitversioning": "^3.6.133",
-    "typescript": "^5.3.3"
+    "typescript": "^5.4.5"
   },
   "peerDependencies": {
     "@dbos-inc/dbos-sdk": "*"

--- a/packages/communicator-random/package.json
+++ b/packages/communicator-random/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "grunt": "^1.6.1",
     "nerdbank-gitversioning": "^3.6.133",
-    "typescript": "^5.3.3"
+    "typescript": "^5.4.5"
   },
   "peerDependencies": {
     "@dbos-inc/dbos-sdk": "*"

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -26,7 +26,7 @@
     "@types/validator": "^13.11.9",
     "grunt": "^1.6.1",
     "nerdbank-gitversioning": "^3.6.133",
-    "typescript": "^5.3.3"
+    "typescript": "^5.4.5"
   },
   "dependencies": {
     "axios": "^1.6.7",

--- a/packages/dbos-cloud/package.json
+++ b/packages/dbos-cloud/package.json
@@ -25,7 +25,7 @@
     "@types/validator": "^13.11.9",
     "grunt": "^1.6.1",
     "nerdbank-gitversioning": "^3.6.133",
-    "typescript": "^5.3.3"
+    "typescript": "^5.4.5"
   },
   "dependencies": {
     "axios": "^1.6.7",

--- a/packages/dbos-openapi/package.json
+++ b/packages/dbos-openapi/package.json
@@ -34,8 +34,8 @@
   "dependencies": {
     "commander": "^11.0.0",
     "openapi-types": "^12.1.3",
-    "ts-json-schema-generator": "^1.5.0",
-    "typescript": "5.3.3",
+    "ts-json-schema-generator": "^1.5.1",
+    "typescript": "5.4.5",
     "yaml": "^2.3.4"
   }
 }


### PR DESCRIPTION
* update ts-json-schema-generator to 1.5.1
* update typescript to 5.4.5

> Note, ts-json-schema-generator moved to ESM in v2. Will need to update at least dbos-openapi to use ESM if we want to use v2 of this library