### PR TITLE
revert wrong type definitions

### DIFF
--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -63,7 +63,8 @@ export interface TestingRuntime {
   setConfig<T>(key: string, newValue: T): void;
 
   // User database operations.
-  queryUserDB<R>(sql: string, ...params: unknown[]): Promise<R[]>; // Execute a raw SQL query on the user database.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  queryUserDB<R>(sql: string, ...params: any[]): Promise<R[]>; // Execute a raw SQL query on the user database.
   createUserSchema(): Promise<void>; // Only valid if using TypeORM. Create tables based on the provided schema.
   dropUserSchema(): Promise<void>; // Only valid if using TypeORM. Drop all tables created by createUserSchema().
 

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -7,7 +7,8 @@ import { GlobalLogger as Logger } from "./telemetry/logs";
 import { WorkflowContextDebug } from "./debugger/debug_workflow";
 
 // Can we call it TransactionFunction
-export type Transaction<R> = (ctxt: TransactionContext<UserDatabaseClient>, ...args: unknown[]) => Promise<R>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Transaction<R> = (ctxt: TransactionContext<any>, ...args: any[]) => Promise<R>;
 
 export interface TransactionConfig {
   isolationLevel?: IsolationLevel;

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -65,8 +65,11 @@ export const StatusString = {
 
 export interface WorkflowContext extends DBOSContext {
   invoke<T extends object>(targetClass: T): WFInvokeFuncs<T>;
-  startChildWorkflow<R>(wf: Workflow<R>, ...args: unknown[]): Promise<WorkflowHandle<R>>;
-  invokeChildWorkflow<R>(wf: Workflow<R>, ...args: unknown[]): Promise<R>;
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  startChildWorkflow<R>(wf: Workflow<R>, ...args: any[]): Promise<WorkflowHandle<R>>;
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  invokeChildWorkflow<R>(wf: Workflow<R>, ...args: any[]): Promise<R>;
+   
   childWorkflow<R>(wf: Workflow<R>, ...args: unknown[]): Promise<WorkflowHandle<R>>; // Deprecated, calls startChildWorkflow
 
   send(destinationUUID: string, message: NonNullable<unknown>, topic?: string): Promise<void>;


### PR DESCRIPTION
This PR reverts wrong type definitions introduced by #448.

Turns out that  `...args: unknown[]` is only a problem when used in interface and type definitions
While in function definitions is fine.
```
function func (a: string, ...args: unknown[]) {}
func('asdas', 2, 'adasd', 124)
```
does not give an error.

Given that I reverted very little of #448 

Although I noticed that in `user_database.ts` there exist definitions like the ones I reverted.
https://github.com/dbos-inc/dbos-transact/blob/e554e3c4f493117ed6279f41269530a1fdbbb51b/src/user_database.ts#L13
https://github.com/dbos-inc/dbos-transact/blob/e554e3c4f493117ed6279f41269530a1fdbbb51b/src/user_database.ts#L17
https://github.com/dbos-inc/dbos-transact/blob/e554e3c4f493117ed6279f41269530a1fdbbb51b/src/user_database.ts#L19

If you wish I could change them in another PR