### PR TITLE
Revert "Reduce usage of "any" (#448)"

### DIFF
--- a/src/communicator.ts
+++ b/src/communicator.ts
@@ -4,8 +4,8 @@ import { WorkflowContextImpl } from "./workflow";
 import { DBOSContext, DBOSContextImpl } from "./context";
 import { WorkflowContextDebug } from "./debugger/debug_workflow";
 
-/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-export type Communicator<R> = (ctxt: CommunicatorContext, ...args: any[]) => Promise<R>;
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type Communicator<T extends any[], R> = (ctxt: CommunicatorContext, ...args: T) => Promise<R>;
 
 export interface CommunicatorConfig {
   retriesAllowed?: boolean; // Should failures be retried? (default true)

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -1,4 +1,5 @@
- import {
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
   DBOSError,
   DBOSInitializationError,
   DBOSWorkflowConflictUUIDError,
@@ -67,17 +68,17 @@ export interface DBOSConfig {
 }
 
 interface WorkflowInfo {
-  workflow: Workflow<unknown>;
+  workflow: Workflow<any, any>;
   config: WorkflowConfig;
 }
 
 interface TransactionInfo {
-  transaction: Transaction<unknown>;
+  transaction: Transaction<any, any>;
   config: TransactionConfig;
 }
 
 interface CommunicatorInfo {
-  communicator: Communicator<unknown>;
+  communicator: Communicator<any, any>;
   config: CommunicatorConfig;
 }
 
@@ -257,15 +258,15 @@ export class DBOSExecutor {
     this.registeredOperations.push(...registeredClassOperations);
     for (const ro of registeredClassOperations) {
       if (ro.workflowConfig) {
-        const wf = ro.registeredFunction as Workflow<unknown>;
+        const wf = ro.registeredFunction as Workflow<any, any>;
         this.#registerWorkflow(wf, {...ro.workflowConfig});
         this.logger.debug(`Registered workflow ${ro.name}`);
       } else if (ro.txnConfig) {
-        const tx = ro.registeredFunction as Transaction<unknown>;
+        const tx = ro.registeredFunction as Transaction<any, any>;
         this.#registerTransaction(tx, ro.txnConfig);
         this.logger.debug(`Registered transaction ${ro.name}`);
       } else if (ro.commConfig) {
-        const comm = ro.registeredFunction as Communicator<unknown>;
+        const comm = ro.registeredFunction as Communicator<any, any>;
         this.#registerCommunicator(comm, ro.commConfig);
         this.logger.debug(`Registered communicator ${ro.name}`);
       }
@@ -346,7 +347,7 @@ export class DBOSExecutor {
 
   /* WORKFLOW OPERATIONS */
 
-  #registerWorkflow<R>(wf: Workflow<R>, config: WorkflowConfig = {}) {
+  #registerWorkflow<T extends any[], R>(wf: Workflow<T, R>, config: WorkflowConfig = {}) {
     if (wf.name === DBOSExecutor.tempWorkflowName || this.workflowInfoMap.has(wf.name)) {
       throw new DBOSError(`Repeated workflow name: ${wf.name}`);
     }
@@ -357,7 +358,7 @@ export class DBOSExecutor {
     this.workflowInfoMap.set(wf.name, workflowInfo);
   }
 
-  #registerTransaction<R>(txn: Transaction<R>, params: TransactionConfig = {}) {
+  #registerTransaction<T extends any[], R>(txn: Transaction<T, R>, params: TransactionConfig = {}) {
     if (this.transactionInfoMap.has(txn.name)) {
       throw new DBOSError(`Repeated Transaction name: ${txn.name}`);
     }
@@ -368,7 +369,7 @@ export class DBOSExecutor {
     this.transactionInfoMap.set(txn.name, txnInfo);
   }
 
-  #registerCommunicator<R>(comm: Communicator<R>, params: CommunicatorConfig = {}) {
+  #registerCommunicator<T extends any[], R>(comm: Communicator<T, R>, params: CommunicatorConfig = {}) {
     if (this.communicatorInfoMap.has(comm.name)) {
       throw new DBOSError(`Repeated Commmunicator name: ${comm.name}`);
     }
@@ -379,7 +380,7 @@ export class DBOSExecutor {
     this.communicatorInfoMap.set(comm.name, commInfo);
   }
 
-  async workflow<R>(wf: Workflow<R>, params: InternalWorkflowParams, ...args: unknown[]): Promise<WorkflowHandle<R>> {
+  async workflow<T extends any[], R>(wf: Workflow<T, R>, params: InternalWorkflowParams, ...args: T): Promise<WorkflowHandle<R>> {
     if (this.debugMode) {
       return this.debugWorkflow(wf, params, undefined, undefined, ...args);
     }
@@ -387,7 +388,7 @@ export class DBOSExecutor {
   }
 
   // If callerUUID and functionID are set, it means the workflow is invoked from within a workflow.
-  async internalWorkflow<R>(wf: Workflow<R>, params: InternalWorkflowParams, callerUUID?: string, callerFunctionID?: number, ...args: unknown[]): Promise<WorkflowHandle<R>> {
+  async internalWorkflow<T extends any[], R>(wf: Workflow<T, R>, params: InternalWorkflowParams, callerUUID?: string, callerFunctionID?: number, ...args: T): Promise<WorkflowHandle<R>> {
     const workflowUUID: string = params.workflowUUID ? params.workflowUUID : this.#generateUUID();
     const presetUUID: boolean = params.workflowUUID ? true : false;
 
@@ -493,7 +494,7 @@ export class DBOSExecutor {
   /**
    * DEBUG MODE workflow execution, skipping all the recording
    */
-  async debugWorkflow<R>(wf: Workflow<R>, params: WorkflowParams, callerUUID?: string, callerFunctionID?: number, ...args: unknown[]): Promise<WorkflowHandle<R>> {
+  async debugWorkflow<T extends any[], R>(wf: Workflow<T, R>, params: WorkflowParams, callerUUID?: string, callerFunctionID?: number, ...args: T): Promise<WorkflowHandle<R>> {
     // In debug mode, we must have a specific workflow UUID.
     if (!params.workflowUUID) {
       throw new DBOSDebuggerError("Workflow UUID not found!");
@@ -534,28 +535,28 @@ export class DBOSExecutor {
     return new InvokedHandle(this.systemDatabase, workflowPromise, workflowUUID, wf.name, callerUUID, callerFunctionID);
   }
 
-  async transaction<R>(txn: Transaction<R>, params: WorkflowParams, ...args: unknown[] ): Promise<R> {
+  async transaction<T extends any[], R>(txn: Transaction<T, R>, params: WorkflowParams, ...args: T): Promise<R> {
     // Create a workflow and call transaction.
-    const temp_workflow = async (ctxt: WorkflowContext, ...args: unknown[]) => {
+    const temp_workflow = async (ctxt: WorkflowContext, ...args: T) => {
       const ctxtImpl = ctxt as WorkflowContextImpl;
       return await ctxtImpl.transaction(txn, ...args);
     };
-    return (await this.workflow<R>(temp_workflow, { ...params, tempWfType: TempWorkflowType.transaction, tempWfName: txn.name }, ...args)).getResult();
+    return (await this.workflow(temp_workflow, { ...params, tempWfType: TempWorkflowType.transaction, tempWfName: txn.name }, ...args)).getResult();
   }
 
-  async external<R>(commFn: Communicator<R>, params: WorkflowParams, ...args: unknown[]): Promise<R> {
+  async external<T extends any[], R>(commFn: Communicator<T, R>, params: WorkflowParams, ...args: T): Promise<R> {
     // Create a workflow and call external.
-    const temp_workflow = async (ctxt: WorkflowContext, ...args: unknown[]) => {
+    const temp_workflow = async (ctxt: WorkflowContext, ...args: T) => {
       const ctxtImpl = ctxt as WorkflowContextImpl;
       return await ctxtImpl.external(commFn, ...args);
     };
     return (await this.workflow(temp_workflow, { ...params, tempWfType: TempWorkflowType.external, tempWfName: commFn.name }, ...args)).getResult();
   }
 
-  async send(destinationUUID: string, message: NonNullable<unknown>, topic?: string, idempotencyKey?: string): Promise<void> {
+  async send<T extends NonNullable<any>>(destinationUUID: string, message: T, topic?: string, idempotencyKey?: string): Promise<void> {
     // Create a workflow and call send.
-    const temp_workflow = async (ctxt: WorkflowContext, destinationUUID: string, message: NonNullable<unknown>, topic?: string) => {
-      return await ctxt.send(destinationUUID, message, topic);
+    const temp_workflow = async (ctxt: WorkflowContext, destinationUUID: string, message: T, topic?: string) => {
+      return await ctxt.send<T>(destinationUUID, message, topic);
     };
     const workflowUUID = idempotencyKey ? destinationUUID + idempotencyKey : undefined;
     return (await this.workflow(temp_workflow, { workflowUUID: workflowUUID, tempWfType: TempWorkflowType.send }, destinationUUID, message, topic)).getResult();
@@ -564,7 +565,7 @@ export class DBOSExecutor {
   /**
    * Wait for a workflow to emit an event, then return its value.
    */
-  async getEvent<T extends NonNullable<unknown>>(workflowUUID: string, key: string, timeoutSeconds: number = DBOSExecutor.defaultNotificationTimeoutSec): Promise<T | null> {
+  async getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds: number = DBOSExecutor.defaultNotificationTimeoutSec): Promise<T | null> {
     return this.systemDatabase.getEvent(workflowUUID, key, timeoutSeconds);
   }
 
@@ -584,7 +585,7 @@ export class DBOSExecutor {
    * A recovery process that by default runs during executor init time.
    * It runs to completion all pending workflows that were executing when the previous executor failed.
    */
-  async recoverPendingWorkflows(executorIDs: string[] = ["local"]): Promise<WorkflowHandle<unknown>[]> {
+  async recoverPendingWorkflows(executorIDs: string[] = ["local"]): Promise<WorkflowHandle<any>[]> {
     const pendingWorkflows: string[] = [];
     for (const execID of executorIDs) {
       if (execID == "local" && process.env.DBOS__VMID) {
@@ -596,7 +597,7 @@ export class DBOSExecutor {
       pendingWorkflows.push(...wIDs);
     }
 
-    const handlerArray: WorkflowHandle<unknown>[] = [];
+    const handlerArray: WorkflowHandle<any>[] = [];
     for (const workflowUUID of pendingWorkflows) {
       try {
         handlerArray.push(await this.executeWorkflowUUID(workflowUUID));
@@ -619,6 +620,7 @@ export class DBOSExecutor {
     const wfInfo: WorkflowInfo | undefined = this.workflowInfoMap.get(wfStatus.workflowName);
 
     if (wfInfo) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       return this.workflow(wfInfo.workflow, { workflowUUID: workflowUUID, parentCtx: parentCtx ?? undefined }, ...inputs);
     }
 
@@ -629,15 +631,16 @@ export class DBOSExecutor {
       throw new DBOSError(`This should never happen! Cannot find workflow info for a non-temporary workflow! UUID ${workflowUUID}, name ${wfName}`);
     }
 
-    let temp_workflow: Workflow<unknown>;
+    let temp_workflow: Workflow<any, any>;
     if (nameArr[1] === TempWorkflowType.transaction) {
       const txnInfo: TransactionInfo | undefined = this.transactionInfoMap.get(nameArr[2]);
       if (!txnInfo) {
         this.logger.error(`Cannot find transaction info for UUID ${workflowUUID}, name ${nameArr[2]}`);
         throw new DBOSNotRegisteredError(nameArr[2]);
       }
-      temp_workflow = async (ctxt: WorkflowContext, ...args: unknown[]) => {
+      temp_workflow = async (ctxt: WorkflowContext, ...args: any[]) => {
         const ctxtImpl = ctxt as WorkflowContextImpl;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument
         return await ctxtImpl.transaction(txnInfo.transaction, ...args);
       };
     } else if (nameArr[1] === TempWorkflowType.external) {
@@ -646,18 +649,21 @@ export class DBOSExecutor {
         this.logger.error(`Cannot find communicator info for UUID ${workflowUUID}, name ${nameArr[2]}`);
         throw new DBOSNotRegisteredError(nameArr[2]);
       }
-      temp_workflow = async (ctxt: WorkflowContext, ...args: unknown[]) => {
+      temp_workflow = async (ctxt: WorkflowContext, ...args: any[]) => {
         const ctxtImpl = ctxt as WorkflowContextImpl;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-argument
         return await ctxtImpl.external(commInfo.communicator, ...args);
       };
     } else if (nameArr[1] === TempWorkflowType.send) {
-      temp_workflow = async (ctxt: WorkflowContext, ...args: unknown[]) => {
-        return await ctxt.send(args[0] as string, args[1] as string, args[2] as string);
+      temp_workflow = async (ctxt: WorkflowContext, ...args: any[]) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        return await ctxt.send<any>(args[0], args[1], args[2]);
       };
     } else {
       this.logger.error(`Unrecognized temporary workflow! UUID ${workflowUUID}, name ${wfName}`)
       throw new DBOSNotRegisteredError(wfName);
     }
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     return this.workflow(temp_workflow, { workflowUUID: workflowUUID, parentCtx: parentCtx ?? undefined }, ...inputs);
   }
 
@@ -705,7 +711,7 @@ export class DBOSExecutor {
       while (finishedCnt < totalSize) {
         let sqlStmt = "INSERT INTO dbos.transaction_outputs (workflow_uuid, function_id, output, error, txn_id, txn_snapshot, created_at) VALUES ";
         let paramCnt = 1;
-        const values: unknown[] = [];
+        const values: any[] = [];
         const batchUUIDs: string[] = [];
         for (const [workflowUUID, wfBuffer] of localBuffer) {
           for (const [funcID, recorded] of wfBuffer) {
@@ -726,6 +732,7 @@ export class DBOSExecutor {
           }
         }
         this.logger.debug(sqlStmt);
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         await this.userDatabase.query(sqlStmt, ...values);
 
         // Clean up after each batch succeeds

--- a/src/dbos-runtime/runtime.ts
+++ b/src/dbos-runtime/runtime.ts
@@ -10,7 +10,8 @@ import { DBOSKafka } from '../kafka/kafka';
 import { DBOSScheduler } from '../scheduler/scheduler';
 
 interface ModuleExports {
-  [key: string]: unknown;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
 }
 
 export interface DBOSRuntimeConfig {
@@ -73,7 +74,7 @@ export class DBOSRuntime {
       let exports: ModuleExports;
       if (fs.existsSync(operations)) {
         const operationsURL = pathToFileURL(operations).href;
-        exports = (await import(operationsURL)) as ModuleExports;
+        exports = (await import(operationsURL)) as Promise<ModuleExports>;
       } else {
         throw new DBOSFailLoadOperationsError(`Failed to load operations from the entrypoint ${entrypoint}`);
       }

--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -1,4 +1,5 @@
- import { DBOSExecutor, DBOSNull, OperationType, dbosNull } from "../dbos-executor";
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { DBOSExecutor, DBOSNull, OperationType, dbosNull } from "../dbos-executor";
 import { transaction_outputs } from "../../schemas/user_db_schema";
 import { Transaction, TransactionContextImpl } from "../transaction";
 import { Communicator } from "../communicator";
@@ -50,15 +51,16 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
 
   invoke<T extends object>(object: T): WFInvokeFuncs<T> {
     const ops = getRegisteredOperations(object);
-    const proxy: Record<string, unknown> = {};
 
+    const proxy: any = {};
     for (const op of ops) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       proxy[op.name] = op.txnConfig
-        ?
-        (...args: unknown[]) => this.transaction(op.registeredFunction as Transaction<unknown>, ...args)
+        ? // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        (...args: any[]) => this.transaction(op.registeredFunction as Transaction<any[], any>, ...args)
         : op.commConfig
-          ?
-          (...args: unknown[]) => this.external(op.registeredFunction as Communicator<unknown>, ...args)
+          ? // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          (...args: any[]) => this.external(op.registeredFunction as Communicator<any[], any>, ...args)
           : undefined;
     }
     return proxy as WFInvokeFuncs<T>;
@@ -97,7 +99,7 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
    * Execute a transactional function in debug mode.
    * If a debug proxy is provided, it connects to a debug proxy and everything should be read-only.
    */
-  async transaction<R>(txn: Transaction<R>, ...args: unknown[]): Promise<R> {
+  async transaction<T extends any[], R>(txn: Transaction<T, R>, ...args: T): Promise<R> {
     const txnInfo = this.#dbosExec.transactionInfoMap.get(txn.name);
     if (txnInfo === undefined) {
       throw new DBOSDebuggerError(`Transaction ${txn.name} not registered!`);
@@ -166,7 +168,7 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
     return check.output; // Always return the recorded result.
   }
 
-  async external<R>(commFn: Communicator<R>, ..._args: unknown[]): Promise<R> {
+  async external<T extends any[], R>(commFn: Communicator<T, R>, ..._args: T): Promise<R> {
     const commConfig = this.#dbosExec.communicatorInfoMap.get(commFn.name);
     if (commConfig === undefined) {
       throw new DBOSDebuggerError(`Communicator ${commFn.name} not registered!`);
@@ -185,22 +187,22 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
   }
 
   // Invoke the debugWorkflow() function instead.
-  async startChildWorkflow<R>(wf: Workflow<R>, ...args: unknown[]): Promise<WorkflowHandle<R>> {
+  async startChildWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>> {
     const funcId = this.functionIDGetIncrement();
     const childUUID: string = this.workflowUUID + "-" + funcId;
     return this.#dbosExec.debugWorkflow(wf, { parentCtx: this, workflowUUID: childUUID }, this.workflowUUID, funcId, ...args);
   }
 
-  async invokeChildWorkflow<R>(wf: Workflow<R>, ...args: unknown[]): Promise<R> {
+  async invokeChildWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<R> {
     return this.startChildWorkflow(wf, ...args).then((handle) => handle.getResult());
   }
 
   // Deprecated
-  async childWorkflow<R>(wf: Workflow<R>, ...args: unknown[]): Promise<WorkflowHandle<R>> {
+  async childWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>> {
     return this.startChildWorkflow(wf, ...args);
   }
 
-  async send(_destinationUUID: string, _message: NonNullable<unknown>, _topic?: string | undefined): Promise<void> {
+  async send<T extends NonNullable<any>>(_destinationUUID: string, _message: T, _topic?: string | undefined): Promise<void> {
     const functionID: number = this.functionIDGetIncrement();
 
     // Original result must exist during replay.
@@ -212,7 +214,7 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
     return;
   }
 
-  async recv<T extends NonNullable<unknown>>(_topic?: string | undefined, _timeoutSeconds?: number | undefined): Promise<T | null> {
+  async recv<T extends NonNullable<any>>(_topic?: string | undefined, _timeoutSeconds?: number | undefined): Promise<T | null> {
     const functionID: number = this.functionIDGetIncrement();
 
     // Original result must exist during replay.
@@ -224,7 +226,7 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
     return check as T | null;
   }
 
-  async setEvent(_key: string, _value: NonNullable<unknown>): Promise<void> {
+  async setEvent<T extends NonNullable<any>>(_key: string, _value: T): Promise<void> {
     const functionID: number = this.functionIDGetIncrement();
     // Original result must exist during replay.
     const check: undefined | DBOSNull = await this.#dbosExec.systemDatabase.checkOperationOutput<undefined>(this.workflowUUID, functionID);
@@ -234,7 +236,7 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
     this.logger.debug("Use recorded setEvent output.");
   }
 
-  async getEvent<T extends NonNullable<unknown>>(_workflowUUID: string, _key: string, _timeoutSeconds?: number | undefined): Promise<T | null> {
+  async getEvent<T extends NonNullable<any>>(_workflowUUID: string, _key: string, _timeoutSeconds?: number | undefined): Promise<T | null> {
     const functionID: number = this.functionIDGetIncrement();
 
     // Original result must exist during replay.

--- a/src/httpServer/handler.ts
+++ b/src/httpServer/handler.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { MethodRegistration, MethodParameter, registerAndWrapFunction, getOrCreateMethodArgsRegistration, MethodRegistrationBase, getRegisteredOperations } from "../decorators";
 import { DBOSExecutor, OperationType } from "../dbos-executor";
 import { DBOSContext, DBOSContextImpl } from "../context";
@@ -12,7 +13,6 @@ import { Communicator } from "../communicator";
 import { APITypes, ArgSources } from "./handlerTypes";
 
 // local type declarations for workflow functions
-/* eslint-disable @typescript-eslint/no-explicit-any */
 type WFFunc = (ctxt: WorkflowContext, ...args: any[]) => Promise<any>;
 export type InvokeFuncs<T> = WFInvokeFuncs<T> & AsyncHandlerWfFuncs<T>;
 
@@ -30,8 +30,8 @@ export interface HandlerContext extends DBOSContext {
   invokeWorkflow<T extends object>(targetClass: T, workflowUUID?: string): SyncHandlerWfFuncs<T>;
   startWorkflow<T extends object>(targetClass: T, workflowUUID?: string): AsyncHandlerWfFuncs<T>;
   retrieveWorkflow<R>(workflowUUID: string): WorkflowHandle<R>;
-  send(destinationUUID: string, message: NonNullable<unknown>, topic?: string, idempotencyKey?: string): Promise<void>;
-  getEvent<T extends NonNullable<unknown>>(workflowUUID: string, key: string, timeoutSeconds?: number): Promise<T | null>;
+  send<T extends NonNullable<any>>(destinationUUID: string, message: T, topic?: string, idempotencyKey?: string): Promise<void>;
+  getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds?: number): Promise<T | null>;
 }
 
 export const RequestIDHeader = "x-request-id";
@@ -101,11 +101,11 @@ export class HandlerContextImpl extends DBOSContextImpl implements HandlerContex
   /* PUBLIC INTERFACE  */
   ///////////////////////
 
-  async send(destinationUUID: string, message: NonNullable<unknown>, topic?: string, idempotencyKey?: string): Promise<void> {
+  async send<T extends NonNullable<any>>(destinationUUID: string, message: T, topic?: string, idempotencyKey?: string): Promise<void> {
     return this.#dbosExec.send(destinationUUID, message, topic, idempotencyKey);
   }
 
-  async getEvent<T extends NonNullable<unknown>>(workflowUUID: string, key: string, timeoutSeconds: number = DBOSExecutor.defaultNotificationTimeoutSec): Promise<T | null> {
+  async getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds: number = DBOSExecutor.defaultNotificationTimeoutSec): Promise<T | null> {
     return this.#dbosExec.getEvent(workflowUUID, key, timeoutSeconds);
   }
 
@@ -119,21 +119,26 @@ export class HandlerContextImpl extends DBOSContextImpl implements HandlerContex
    */
   mainInvoke<T extends object>(object: T, workflowUUID: string | undefined, asyncWf: boolean): InvokeFuncs<T> {
     const ops = getRegisteredOperations(object);
-    const proxy: Record<string, unknown> = {};
+    const proxy: any = {};
     const params = { workflowUUID: workflowUUID, parentCtx: this };
-
     for (const op of ops) {
       if (asyncWf) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         proxy[op.name] = op.txnConfig
-          ? (...args: unknown[]) => this.#transaction(op.registeredFunction as Transaction<unknown>, params, ...args)
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          ? (...args: any[]) => this.#transaction(op.registeredFunction as Transaction<any[], any>, params, ...args)
           : op.workflowConfig
-          ? (...args: unknown[]) => this.#workflow(op.registeredFunction as Workflow<unknown>, params, ...args)
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          ? (...args: any[]) => this.#workflow(op.registeredFunction as Workflow<any[], any>, params, ...args)
           : op.commConfig
-          ? (...args: unknown[]) => this.#external(op.registeredFunction as Communicator<unknown>, params, ...args)
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          ? (...args: any[]) => this.#external(op.registeredFunction as Communicator<any[], any>, params, ...args)
           : undefined;
       } else {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         proxy[op.name] = op.workflowConfig
-          ? (...args: unknown[]) => this.#workflow(op.registeredFunction as Workflow<unknown>, params, ...args).then((handle) => handle.getResult())
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          ? (...args: any[]) => this.#workflow(op.registeredFunction as Workflow<any[], any>, params, ...args).then((handle) => handle.getResult())
           : undefined;
       }
     }
@@ -156,15 +161,15 @@ export class HandlerContextImpl extends DBOSContextImpl implements HandlerContex
   /* PRIVATE METHODS */
   /////////////////////
 
-  async #workflow<R>(wf: Workflow<R>, params: WorkflowParams, ...args: unknown[]): Promise<WorkflowHandle<R>> {
+  async #workflow<T extends any[], R>(wf: Workflow<T, R>, params: WorkflowParams, ...args: T): Promise<WorkflowHandle<R>> {
     return this.#dbosExec.workflow(wf, params, ...args);
   }
 
-  async #transaction<R>(txn: Transaction<R>, params: WorkflowParams, ...args: unknown[]): Promise<R> {
+  async #transaction<T extends any[], R>(txn: Transaction<T, R>, params: WorkflowParams, ...args: T): Promise<R> {
     return this.#dbosExec.transaction(txn, params, ...args);
   }
 
-  async #external<R>(commFn: Communicator<R>, params: WorkflowParams, ...args: unknown[]): Promise<R> {
+  async #external<T extends any[], R>(commFn: Communicator<T, R>, params: WorkflowParams, ...args: T): Promise<R> {
     return this.#dbosExec.external(commFn, params, ...args);
   }
 }

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -285,11 +285,11 @@ async checkPortAvailability(port: number, host: string): Promise<void> {
             // - Otherwise, we return 500.
             const wfParams = { parentCtx: oc, workflowUUID: headerWorkflowUUID };
             if (ro.txnConfig) {
-              koaCtxt.body = await dbosExec.transaction(ro.registeredFunction as Transaction<unknown>, wfParams, ...args);
+              koaCtxt.body = await dbosExec.transaction(ro.registeredFunction as Transaction<unknown[], unknown>, wfParams, ...args);
             } else if (ro.workflowConfig) {
-              koaCtxt.body = await (await dbosExec.workflow(ro.registeredFunction as Workflow<unknown>, wfParams, ...args)).getResult();
+              koaCtxt.body = await (await dbosExec.workflow(ro.registeredFunction as Workflow<unknown[], unknown>, wfParams, ...args)).getResult();
             } else if (ro.commConfig) {
-              koaCtxt.body = await dbosExec.external(ro.registeredFunction as Communicator<unknown>, wfParams, ...args);
+              koaCtxt.body = await dbosExec.external(ro.registeredFunction as Communicator<unknown[], unknown>, wfParams, ...args);
             } else {
               // Directly invoke the handler code.
               const retValue = await ro.invoke(undefined, [oc, ...args]);

--- a/src/kafka/kafka.ts
+++ b/src/kafka/kafka.ts
@@ -124,10 +124,10 @@ export class DBOSKafka {
             // We can only guarantee exactly-once-per-message execution of transactions and workflows.
             if (ro.txnConfig) {
               // Execute the transaction
-              await this.dbosExec.transaction(ro.registeredFunction as Transaction<unknown>, wfParams, ...args);
+              await this.dbosExec.transaction(ro.registeredFunction as Transaction<unknown[], unknown>, wfParams, ...args);
             } else if (ro.workflowConfig) {
               // Safely start the workflow
-              await this.dbosExec.workflow(ro.registeredFunction as Workflow<unknown>, wfParams, ...args);
+              await this.dbosExec.workflow(ro.registeredFunction as Workflow<unknown[], unknown>, wfParams, ...args);
             }
           },
         })

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -168,7 +168,7 @@ class DetachableLoop {
             // We currently only support scheduled workflows
             if (this.scheduledMethod.workflowConfig) {
                 // Execute the workflow
-                await this.dbosExec.workflow(this.scheduledMethod.registeredFunction as Workflow<unknown>, wfParams, ...args);
+                await this.dbosExec.workflow(this.scheduledMethod.registeredFunction as Workflow<ScheduledArgs, unknown>, wfParams, ...args);
             }
             else {
                 this.dbosExec.logger.error(`Function ${this.scheduledMethod.name} is @scheduled but not a workflow`);

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { deserializeError, serializeError } from "serialize-error";
 import { DBOSExecutor, dbosNull, DBOSNull } from "./dbos-executor";
 import { DatabaseError, Pool, PoolClient, Notification, PoolConfig, Client } from "pg";
@@ -15,14 +17,14 @@ export interface SystemDatabase {
   destroy(): Promise<void>;
 
   checkWorkflowOutput<R>(workflowUUID: string): Promise<DBOSNull | R>;
-  initWorkflowStatus<T extends unknown[]>(bufferedStatus: WorkflowStatusInternal, args: T): Promise<T>;
+  initWorkflowStatus<T extends any[]>(bufferedStatus: WorkflowStatusInternal, args: T): Promise<T>;
   bufferWorkflowOutput(workflowUUID: string, status: WorkflowStatusInternal): void;
   flushWorkflowSystemBuffers(): Promise<void>;
   recordWorkflowError(workflowUUID: string, status: WorkflowStatusInternal): Promise<void>;
 
   getPendingWorkflows(executorID: string): Promise<Array<string>>;
-  bufferWorkflowInputs<T extends unknown[]>(workflowUUID: string, args: T) : void;
-  getWorkflowInputs<T extends unknown[]>(workflowUUID: string): Promise<T | null>;
+  bufferWorkflowInputs<T extends any[]>(workflowUUID: string, args: T) : void;
+  getWorkflowInputs<T extends any[]>(workflowUUID: string): Promise<T | null>;
 
   checkOperationOutput<R>(workflowUUID: string, functionID: number): Promise<DBOSNull | R>;
   recordOperationOutput<R>(workflowUUID: string, functionID: number, output: R): Promise<void>;
@@ -33,11 +35,11 @@ export interface SystemDatabase {
 
   sleepms(workflowUUID: string, functionID: number, duration: number): Promise<void>;
 
-  send(workflowUUID: string, functionID: number, destinationUUID: string, message: NonNullable<unknown>, topic?: string): Promise<void>;
-  recv<T extends NonNullable<unknown>>(workflowUUID: string, functionID: number, topic?: string, timeoutSeconds?: number): Promise<T | null>;
+  send<T extends NonNullable<any>>(workflowUUID: string, functionID: number, destinationUUID: string, message: T, topic?: string): Promise<void>;
+  recv<T extends NonNullable<any>>(workflowUUID: string, functionID: number, topic?: string, timeoutSeconds?: number): Promise<T | null>;
 
-  setEvent(workflowUUID: string, functionID: number, key: string, value: NonNullable<unknown>): Promise<void>;
-  getEvent<T extends NonNullable<unknown>>(workflowUUID: string, key: string, timeoutSeconds: number, callerUUID?: string, functionID?: number): Promise<T | null>;
+  setEvent<T extends NonNullable<any>>(workflowUUID: string, functionID: number, key: string, value: T): Promise<void>;
+  getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds: number, callerUUID?: string, functionID?: number): Promise<T | null>;
 
   // Scheduler queries
   //  These two maintain exactly once - make sure we kick off the workflow at least once, and wf unique ID does the rest
@@ -88,7 +90,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
   readonly workflowEventsMap: Record<string, () => void> = {};
 
   readonly workflowStatusBuffer: Map<string, WorkflowStatusInternal> = new Map();
-  readonly workflowInputsBuffer: Map<string, unknown[]> = new Map();
+  readonly workflowInputsBuffer: Map<string, any[]> = new Map();
   readonly flushBatchSize = 100;
   static readonly connectionTimeoutMillis = 10000;  // 10 second timeout
 
@@ -132,7 +134,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     }
   }
 
-  async initWorkflowStatus<T extends unknown[]>(initStatus: WorkflowStatusInternal, args: T): Promise<T> {
+  async initWorkflowStatus<T extends any[]>(initStatus: WorkflowStatusInternal, args: T): Promise<T> {
     await this.pool.query<workflow_status>(
       `INSERT INTO ${DBOSExecutor.systemDBSchemaName}.workflow_status (workflow_uuid, status, name, authenticated_user, assumed_role, authenticated_roles, request, output, executor_id, created_at) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) ON CONFLICT (workflow_uuid) DO NOTHING`,
       [initStatus.workflowUUID, initStatus.status, initStatus.name, initStatus.authenticatedUser, initStatus.assumedRole, JSON.stringify(initStatus.authenticatedRoles), JSON.stringify(initStatus.request), null, initStatus.executorID, initStatus.createdAt]
@@ -166,7 +168,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
       while (finishedCnt < totalSize) {
         let sqlStmt = `INSERT INTO ${DBOSExecutor.systemDBSchemaName}.workflow_status (workflow_uuid, status, name, authenticated_user, assumed_role, authenticated_roles, request, output, executor_id, created_at, updated_at) VALUES `;
         let paramCnt = 1;
-        const values: unknown[] = [];
+        const values: any[] = [];
         const batchUUIDs: string[] = [];
         for (const [workflowUUID, status] of localBuffer) {
           if (paramCnt > 1) {
@@ -219,7 +221,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     return rows.map(i => i.workflow_uuid);
   }
 
-  bufferWorkflowInputs<T extends unknown[]>(workflowUUID: string, args: T): void {
+  bufferWorkflowInputs<T extends any[]>(workflowUUID: string, args: T): void {
     this.workflowInputsBuffer.set(workflowUUID, args);
   }
 
@@ -232,7 +234,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
       while (finishedCnt < totalSize) {
         let sqlStmt = `INSERT INTO ${DBOSExecutor.systemDBSchemaName}.workflow_inputs (workflow_uuid, inputs) VALUES `;
         let paramCnt = 1;
-        const values: unknown[] = [];
+        const values: any[] = [];
         const batchUUIDs: string[] = [];
         for (const [workflowUUID, args] of localBuffer) {
           finishedCnt++;
@@ -275,7 +277,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     return;
   }
 
-  async getWorkflowInputs<T extends unknown[]>(workflowUUID: string): Promise<T | null> {
+  async getWorkflowInputs<T extends any[]>(workflowUUID: string): Promise<T | null> {
     const { rows } = await this.pool.query<workflow_inputs>(
       `SELECT inputs FROM ${DBOSExecutor.systemDBSchemaName}.workflow_inputs WHERE workflow_uuid=$1`,
       [workflowUUID]
@@ -362,7 +364,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
 
   readonly nullTopic = "__null__topic__";
 
-  async send(workflowUUID: string, functionID: number, destinationUUID: string, message: NonNullable<unknown>, topic?: string): Promise<void> {
+  async send<T extends NonNullable<any>>(workflowUUID: string, functionID: number, destinationUUID: string, message: T, topic?: string): Promise<void> {
     topic = topic ?? this.nullTopic;
     const client: PoolClient = await this.pool.connect();
 
@@ -396,7 +398,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     client.release();
   }
 
-  async recv<T extends NonNullable<unknown>>(workflowUUID: string, functionID: number, topic?: string, timeoutSeconds: number = DBOSExecutor.defaultNotificationTimeoutSec): Promise<T | null> {
+  async recv<T extends NonNullable<any>>(workflowUUID: string, functionID: number, topic?: string, timeoutSeconds: number = DBOSExecutor.defaultNotificationTimeoutSec): Promise<T | null> {
     topic = topic ?? this.nullTopic;
     // First, check for previous executions.
     const checkRows = (await this.pool.query<operation_outputs>(`SELECT output FROM ${DBOSExecutor.systemDBSchemaName}.operation_outputs WHERE workflow_uuid=$1 AND function_id=$2`, [workflowUUID, functionID])).rows;
@@ -448,7 +450,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
       [workflowUUID, topic])).rows;
     let message: T | null = null;
     if (finalRecvRows.length > 0) {
-      message = JSON.parse(finalRecvRows[0].message) as T
+      message = JSON.parse(finalRecvRows[0].message) as T;
     }
     await this.recordNotificationOutput(client, workflowUUID, functionID, message);
     await client.query(`COMMIT`);
@@ -456,7 +458,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     return message;
   }
 
-  async setEvent(workflowUUID: string, functionID: number, key: string, message: NonNullable<unknown>): Promise<void> {
+  async setEvent<T extends NonNullable<any>>(workflowUUID: string, functionID: number, key: string, message: T): Promise<void> {
     const client: PoolClient = await this.pool.connect();
 
     await client.query("BEGIN ISOLATION LEVEL READ COMMITTED");
@@ -480,7 +482,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     client.release();
   }
 
-  async getEvent<T extends NonNullable<unknown>>(workflowUUID: string, key: string, timeoutSeconds: number, callerUUID?: string, functionID?: number): Promise<T | null> {
+  async getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds: number, callerUUID?: string, functionID?: number): Promise<T | null> {
     // Check if the operation has been done before for OAOO (only do this inside a workflow).
     if (callerUUID !== undefined && functionID !== undefined) {
       const { rows } = await this.pool.query<operation_outputs>(`SELECT output FROM ${DBOSExecutor.systemDBSchemaName}.operation_outputs WHERE workflow_uuid=$1 AND function_id=$2`, [callerUUID, functionID]);

--- a/src/testing/testing_runtime.ts
+++ b/src/testing/testing_runtime.ts
@@ -1,4 +1,5 @@
- import { IncomingMessage } from "http";
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { IncomingMessage } from "http";
 import { Communicator } from "../communicator";
 import { HTTPRequest, DBOSContextImpl } from "../context";
 import { getRegisteredOperations } from "../decorators";
@@ -52,8 +53,8 @@ export interface TestingRuntime {
   invokeWorkflow<T extends object>(targetClass: T, workflowUUID?: string, params?: WorkflowInvokeParams): SyncHandlerWfFuncs<T>;
   startWorkflow<T extends object>(targetClass: T, workflowUUID?: string, params?: WorkflowInvokeParams): AsyncHandlerWfFuncs<T>;
   retrieveWorkflow<R>(workflowUUID: string): WorkflowHandle<R>;
-  send(destinationUUID: string, message: NonNullable<unknown>, topic?: string, idempotencyKey?: string): Promise<void>;
-  getEvent<T extends NonNullable<unknown>>(workflowUUID: string, key: string, timeoutSeconds?: number): Promise<T | null>;
+  send<T extends NonNullable<any>>(destinationUUID: string, message: T, topic?: string, idempotencyKey?: string): Promise<void>;
+  getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds?: number): Promise<T | null>;
 
   getHandlersCallback(): (req: IncomingMessage | Http2ServerRequest, res: ServerResponse | Http2ServerResponse) => Promise<void>;
   getAdminCallback(): (req: IncomingMessage | Http2ServerRequest, res: ServerResponse | Http2ServerResponse) => Promise<void>;
@@ -63,7 +64,7 @@ export interface TestingRuntime {
   setConfig<T>(key: string, newValue: T): void;
 
   // User database operations.
-  queryUserDB<R>(sql: string, ...params: unknown[]): Promise<R[]>; // Execute a raw SQL query on the user database.
+  queryUserDB<R>(sql: string, ...params: any[]): Promise<R[]>; // Execute a raw SQL query on the user database.
   createUserSchema(): Promise<void>; // Only valid if using TypeORM. Create tables based on the provided schema.
   dropUserSchema(): Promise<void>; // Only valid if using TypeORM. Drop all tables created by createUserSchema().
 
@@ -143,7 +144,8 @@ export class TestingRuntimeImpl implements TestingRuntime {
   mainInvoke<T extends object>(object: T, workflowUUID: string | undefined, params: WorkflowInvokeParams | undefined, asyncWf: boolean): InvokeFuncs<T> {
     const dbosExec = this.getDBOSExec();
     const ops = getRegisteredOperations(object);
-    const proxy: Record<string, unknown> = {};
+
+    const proxy: any = {};
 
     // Creates a context to pass in necessary info.
     const span = dbosExec.tracer.startSpan("test");
@@ -155,16 +157,22 @@ export class TestingRuntimeImpl implements TestingRuntime {
     const wfParams: WorkflowParams = { workflowUUID: workflowUUID, parentCtx: oc };
     for (const op of ops) {
       if (asyncWf) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         proxy[op.name] = op.txnConfig
-          ? (...args: unknown[]) => dbosExec.transaction(op.registeredFunction as Transaction<unknown>, wfParams, ...args)
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          ? (...args: any[]) => dbosExec.transaction(op.registeredFunction as Transaction<any[], any>, wfParams, ...args)
           : op.workflowConfig
-          ? (...args: unknown[]) => dbosExec.workflow(op.registeredFunction as Workflow<unknown>, wfParams, ...args)
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          ? (...args: any[]) => dbosExec.workflow(op.registeredFunction as Workflow<any[], any>, wfParams, ...args)
           : op.commConfig
-          ? (...args: unknown[]) => dbosExec.external(op.registeredFunction as Communicator<unknown>, wfParams, ...args)
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          ? (...args: any[]) => dbosExec.external(op.registeredFunction as Communicator<any[], any>, wfParams, ...args)
           : undefined;
       } else {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         proxy[op.name] = op.workflowConfig
-          ? (...args: unknown[]) => dbosExec.workflow(op.registeredFunction as Workflow<unknown>, wfParams, ...args).then((handle) => handle.getResult())
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          ? (...args: any[]) => dbosExec.workflow(op.registeredFunction as Workflow<any[], any>, wfParams, ...args).then((handle) => handle.getResult())
           : undefined;
       }
     }
@@ -200,11 +208,11 @@ export class TestingRuntimeImpl implements TestingRuntime {
     return this.#server.adminApp.callback();
   }
 
-  async send(destinationUUID: string, message: NonNullable<unknown>, topic?: string, idempotencyKey?: string): Promise<void> {
+  async send<T extends NonNullable<any>>(destinationUUID: string, message: T, topic?: string, idempotencyKey?: string): Promise<void> {
     return this.getDBOSExec().send(destinationUUID, message, topic, idempotencyKey);
   }
 
-  async getEvent<T extends NonNullable<unknown>>(workflowUUID: string, key: string, timeoutSeconds: number = DBOSExecutor.defaultNotificationTimeoutSec): Promise<T | null> {
+  async getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds: number = DBOSExecutor.defaultNotificationTimeoutSec): Promise<T | null> {
     return this.getDBOSExec().getEvent(workflowUUID, key, timeoutSeconds);
   }
 
@@ -212,7 +220,8 @@ export class TestingRuntimeImpl implements TestingRuntime {
     return this.getDBOSExec().retrieveWorkflow(workflowUUID);
   }
 
-  async queryUserDB<R>(sql: string, ...params: unknown[]): Promise<R[]> {
+  async queryUserDB<R>(sql: string, ...params: any[]): Promise<R[]> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     return this.getDBOSExec().userDatabase.query(sql, ...params);
   }
 

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { UserDatabaseName, UserDatabaseClient } from "./user_database";
 import { WorkflowContextImpl } from "./workflow";
 import { Span } from "@opentelemetry/sdk-trace-base";
@@ -7,7 +8,7 @@ import { GlobalLogger as Logger } from "./telemetry/logs";
 import { WorkflowContextDebug } from "./debugger/debug_workflow";
 
 // Can we call it TransactionFunction
-export type Transaction<R> = (ctxt: TransactionContext<UserDatabaseClient>, ...args: unknown[]) => Promise<R>;
+export type Transaction<T extends any[], R> = (ctxt: TransactionContext<any>, ...args: T) => Promise<R>;
 
 export interface TransactionConfig {
   isolationLevel?: IsolationLevel;

--- a/src/user_database.ts
+++ b/src/user_database.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Pool, PoolConfig, PoolClient, DatabaseError as PGDatabaseError, QueryResultRow } from "pg";
 import { createUserDBSchema, userDBIndex, userDBSchema } from "../schemas/user_db_schema";
 import { IsolationLevel, TransactionConfig } from "./transaction";
@@ -408,7 +409,9 @@ export class KnexUserDatabase implements UserDatabase {
 
   async queryWithClient<R, T extends unknown[]>(client: Knex, sql: string, ...uparams: T): Promise<R[]> {
     const knexSql = sql.replace(/\$\d+/g, '?'); // Replace $1, $2... with ?
-    const params = uparams.map(i => i === undefined ? null : i); // Set undefined parameters to null.
+    let params = uparams as any[];
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    params = params.map(i => i === undefined ? null : i); // Set undefined parameters to null.
     const rows = await client.raw<R>(knexSql, params) as { rows: R[] };
     return rows.rows;
   }

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { DBOSExecutor, DBOSNull, OperationType, dbosNull } from "./dbos-executor";
 import { transaction_outputs } from "../schemas/user_db_schema";
 import { IsolationLevel, Transaction, TransactionContext, TransactionContextImpl } from "./transaction";
@@ -12,18 +13,14 @@ import { Span } from "@opentelemetry/sdk-trace-base";
 import { HTTPRequest, DBOSContext, DBOSContextImpl } from './context';
 import { getRegisteredOperations } from "./decorators";
 
-/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-export type Workflow<R> = (ctxt: WorkflowContext, ...args: any[]) => Promise<R>;
+export type Workflow<T extends any[], R> = (ctxt: WorkflowContext, ...args: T) => Promise<R>;
 
 // Utility type that removes the initial parameter of a function
-/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export type TailParameters<T extends (arg: any, args: any[]) => any> = T extends (arg: any, ...args: infer P) => any ? P : never;
 
 // local type declarations for transaction and communicator functions
-/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-type TxFunc = (ctxt: TransactionContext<any>, ...args: any[]) => Promise<unknown>;
-/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-type CommFunc = (ctxt: CommunicatorContext, ...args: any[]) => Promise<unknown>;
+type TxFunc = (ctxt: TransactionContext<any>, ...args: any[]) => Promise<any>;
+type CommFunc = (ctxt: CommunicatorContext, ...args: any[]) => Promise<any>;
 
 // Utility type that only includes transaction/communicator functions + converts the method signature to exclude the context parameter
 export type WFInvokeFuncs<T> = {
@@ -65,15 +62,15 @@ export const StatusString = {
 
 export interface WorkflowContext extends DBOSContext {
   invoke<T extends object>(targetClass: T): WFInvokeFuncs<T>;
-  startChildWorkflow<R>(wf: Workflow<R>, ...args: unknown[]): Promise<WorkflowHandle<R>>;
-  invokeChildWorkflow<R>(wf: Workflow<R>, ...args: unknown[]): Promise<R>;
-  childWorkflow<R>(wf: Workflow<R>, ...args: unknown[]): Promise<WorkflowHandle<R>>; // Deprecated, calls startChildWorkflow
+  startChildWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>>;
+  invokeChildWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<R>;
+  childWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>>; // Deprecated, calls startChildWorkflow
 
-  send(destinationUUID: string, message: NonNullable<unknown>, topic?: string): Promise<void>;
-  recv<T extends NonNullable<unknown>>(topic?: string, timeoutSeconds?: number): Promise<T | null>;
-  setEvent(key: string, value: NonNullable<unknown>): Promise<void>;
+  send<T extends NonNullable<any>>(destinationUUID: string, message: T, topic?: string): Promise<void>;
+  recv<T extends NonNullable<any>>(topic?: string, timeoutSeconds?: number): Promise<T | null>;
+  setEvent<T extends NonNullable<any>>(key: string, value: T): Promise<void>;
 
-  getEvent<T extends NonNullable<unknown>>(workflowUUID: string, key: string, timeoutSeconds?: number): Promise<T | null>;
+  getEvent<T extends NonNullable<any>>(workflowUUID: string, key: string, timeoutSeconds?: number): Promise<T | null>;
   retrieveWorkflow<R>(workflowUUID: string): WorkflowHandle<R>;
 
   sleepms(durationMS: number): Promise<void>;
@@ -178,7 +175,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
     try {
       let sqlStmt = "INSERT INTO dbos.transaction_outputs (workflow_uuid, function_id, output, error, txn_id, txn_snapshot, created_at) VALUES ";
       let paramCnt = 1;
-      const values: unknown[] = [];
+      const values: any[] = [];
       for (const funcID of funcIDs) {
         // Capture output and also transaction snapshot information.
         // Initially, no txn_id because no queries executed.
@@ -193,6 +190,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
         values.push(this.workflowUUID, funcID, JSON.stringify(output), JSON.stringify(null), txnSnapshot, createdAt);
       }
       this.logger.debug(sqlStmt);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       await this.#dbosExec.userDatabase.queryWithClient(client, sqlStmt, ...values);
     } catch (error) {
       if (this.#dbosExec.userDatabase.isKeyConflictError(error)) {
@@ -245,19 +243,19 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
    * We pass in itself as a parent context and assign the child workflow with a deterministic UUID "this.workflowUUID-functionID".
    * We also pass in its own workflowUUID and function ID so the invoked handle is deterministic.
    */
-  async startChildWorkflow<R>(wf: Workflow<R>, ...args: unknown[]): Promise<WorkflowHandle<R>> {
+  async startChildWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>> {
     // Note: cannot use invoke for childWorkflow because of potential recursive types on the workflow itself.
     const funcId = this.functionIDGetIncrement();
     const childUUID: string = this.workflowUUID + "-" + funcId;
     return this.#dbosExec.internalWorkflow(wf, { parentCtx: this, workflowUUID: childUUID }, this.workflowUUID, funcId, ...args);
   }
 
-  async invokeChildWorkflow<R>(wf: Workflow<R>, ...args: unknown[]): Promise<R> {
+  async invokeChildWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<R> {
     return this.startChildWorkflow(wf, ...args).then((handle) => handle.getResult());
   }
 
   // Deprecated
-  async childWorkflow<R>(wf: Workflow<R>, ...args: unknown[]): Promise<WorkflowHandle<R>> {
+  async childWorkflow<T extends any[], R>(wf: Workflow<T, R>, ...args: T): Promise<WorkflowHandle<R>> {
     return this.startChildWorkflow(wf, ...args);
   }
 
@@ -267,7 +265,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
    * If the transaction encounters a Postgres serialization error, retry it.
    * If it encounters any other error, throw it.
    */
-  async transaction<R>(txn: Transaction<R>, ...args: unknown[]): Promise<R> {
+  async transaction<T extends any[], R>(txn: Transaction<T, R>, ...args: T): Promise<R> {
     const txnInfo = this.#dbosExec.transactionInfoMap.get(txn.name);
     if (txnInfo === undefined) {
       throw new DBOSNotRegisteredError(txn.name);
@@ -378,7 +376,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
    * If it encounters any error, retry according to its configured retry policy until the maximum number of attempts is reached, then throw an DBOSError.
    * The communicator may execute many times, but once it is complete, it will not re-execute.
    */
-  async external<R>(commFn: Communicator<R>, ...args: unknown[]): Promise<R> {
+  async external<T extends any[], R>(commFn: Communicator<T, R>, ...args: T): Promise<R> {
     const commInfo = this.#dbosExec.communicatorInfoMap.get(commFn.name);
     if (commInfo === undefined) {
       throw new DBOSNotRegisteredError(commFn.name);
@@ -473,7 +471,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
    * Send a message to a workflow identified by a UUID.
    * The message can optionally be tagged with a topic.
    */
-  async send(destinationUUID: string, message: NonNullable<unknown>, topic?: string): Promise<void> {
+  async send<T extends NonNullable<any>>(destinationUUID: string, message: T, topic?: string): Promise<void> {
     const functionID: number = this.functionIDGetIncrement();
 
     await this.#dbosExec.userDatabase.transaction(async (client: UserDatabaseClient) => {
@@ -489,7 +487,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
    * If a topic is specified, retrieve the oldest message tagged with that topic.
    * Otherwise, retrieve the oldest message with no topic.
    */
-  async recv<T extends NonNullable<unknown>>(topic?: string, timeoutSeconds: number = DBOSExecutor.defaultNotificationTimeoutSec): Promise<T| null> {
+  async recv<T extends NonNullable<any>>(topic?: string, timeoutSeconds: number = DBOSExecutor.defaultNotificationTimeoutSec): Promise<T | null> {
     const functionID: number = this.functionIDGetIncrement();
 
     await this.#dbosExec.userDatabase.transaction(async (client: UserDatabaseClient) => {
@@ -504,7 +502,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
    * Emit a workflow event, represented as a key-value pair.
    * Events are immutable once set.
    */
-  async setEvent(key: string, value: NonNullable<unknown>) {
+  async setEvent<T extends NonNullable<any>>(key: string, value: T) {
     const functionID: number = this.functionIDGetIncrement();
 
     await this.#dbosExec.userDatabase.transaction(async (client: UserDatabaseClient) => {
@@ -521,13 +519,16 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
    */
   invoke<T extends object>(object: T): WFInvokeFuncs<T> {
     const ops = getRegisteredOperations(object);
-    const proxy: Record<string, unknown> = {};
 
+    const proxy: any = {};
     for (const op of ops) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       proxy[op.name] = op.txnConfig
-        ? (...args: unknown[]) => this.transaction(op.registeredFunction as Transaction<unknown>, ...args)
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        ? (...args: any[]) => this.transaction(op.registeredFunction as Transaction<any[], any>, ...args)
         : op.commConfig
-          ? (...args: unknown[]) => this.external(op.registeredFunction as Communicator<unknown>, ...args)
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          ? (...args: any[]) => this.external(op.registeredFunction as Communicator<any[], any>, ...args)
           : undefined;
     }
     return proxy as WFInvokeFuncs<T>;
@@ -536,7 +537,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
   /**
    * Wait for a workflow to emit an event, then return its value.
    */
-  getEvent<T extends NonNullable<unknown>>(targetUUID: string, key: string, timeoutSeconds: number = DBOSExecutor.defaultNotificationTimeoutSec): Promise<T | null> {
+  getEvent<T extends NonNullable<any>>(targetUUID: string, key: string, timeoutSeconds: number = DBOSExecutor.defaultNotificationTimeoutSec): Promise<T | null> {
     const functionID: number = this.functionIDGetIncrement();
     return this.#dbosExec.systemDatabase.getEvent(targetUUID, key, timeoutSeconds, this.workflowUUID, functionID);
   }

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -315,6 +315,7 @@ class DBOSTestClass {
     await ctxt.send(destinationUUID, "message2");
   }
 
+
   @Workflow()
   static async setEventWorkflow(ctxt: WorkflowContext) {
     await ctxt.setEvent("key1", "value1");


### PR DESCRIPTION
This reverts commit 8f1b5d4f44bb6dfb80a049693fb78f7125789451 as it included breaking API changes. It caused numerous failures on our demo applications and in our staging environment and cannot be released in its current state. The changes in that PR are good, but we need to introduce them gradually and carefully (likely in multiple smaller PRs) and verify they don't cause regressions.