### PR TITLE
Suppress Dev Dependency Warnings (#477)

### DIFF
--- a/packages/create/init.ts
+++ b/packages/create/init.ts
@@ -131,8 +131,8 @@ export async function init(appName: string, templateName: string) {
   const packageJson: { name: string } = JSON.parse(fs.readFileSync(packageJsonName, 'utf-8')) as { name: string };
   packageJson.name = appName;
   fs.writeFileSync(packageJsonName, JSON.stringify(packageJson, null, 2), 'utf-8');
-  execSync("npm install --no-fund --save @dbos-inc/dbos-sdk@latest", {cwd: appName, stdio: 'inherit'})
-  execSync("npm i --no-fund", {cwd: appName, stdio: 'inherit'})
+  execSync("npm install --no-fund --save @dbos-inc/dbos-sdk@latest --loglevel=error", {cwd: appName, stdio: 'inherit'})
+  execSync("npm i --no-fund --loglevel=error", {cwd: appName, stdio: 'inherit'})
   execSync("npm install --no-fund --save-dev @dbos-inc/dbos-cloud@latest", {cwd: appName, stdio: 'inherit'})
   console.log("Application initialized successfully!")
 }


### PR DESCRIPTION
The latest versions of some of our popular dev dependencies (`jest` and `ts-jest`) contain deprecated dependencies that print warnings when installed. For now, we suppress those warnings. Going forward, we need to:

- Upgrade to the next version of `jest` and `ts-jest` when they're released.
- Upgrade to the latest `eslint` soon. This is difficult because it completely changes how the linter is configured, so we'll have to redo our linter configuration files from scratch.
(https://github.com/dbos-inc/dbos-transact/issues/458)