### PR TITLE
Check existence before create schema/table

### DIFF
--- a/src/dbos-runtime/migrate.ts
+++ b/src/dbos-runtime/migrate.ts
@@ -4,6 +4,7 @@ import { ConfigFile, constructPoolConfig } from "./config";
 import { PoolConfig, Client } from "pg";
 import { createUserDBSchema, userDBIndex, userDBSchema } from "../../schemas/user_db_schema";
 import { ExistenceCheck, migrateSystemDatabase } from "../system_database";
+import { schemaExistsQuery, txnOutputIndexExistsQuery, txnOutputTableExistsQuery } from "../user_database";
 
 export async function migrate(configFile: ConfigFile, logger: GlobalLogger) {
   if (!configFile.database.password) {
@@ -119,10 +120,17 @@ async function createDBOSTables(configFile: ConfigFile) {
   await pgUserClient.connect();
 
   // Create DBOS table/schema in user DB.
-  const schemaExists = await pgUserClient.query<ExistenceCheck>(`SELECT EXISTS (SELECT FROM information_schema.schemata WHERE schema_name = 'dbos')`);
+  // Always check if the schema/table exists before creating it to avoid locks.
+  const schemaExists = await pgUserClient.query<ExistenceCheck>(schemaExistsQuery);
   if (!schemaExists.rows[0].exists) {
     await pgUserClient.query(createUserDBSchema);
+  }
+  const txnOutputTableExists = await pgUserClient.query<ExistenceCheck>(txnOutputTableExistsQuery);
+  if (!txnOutputTableExists.rows[0].exists) {
     await pgUserClient.query(userDBSchema);
+  }
+  const txnIndexExists = await pgUserClient.query<ExistenceCheck>(txnOutputIndexExistsQuery);
+  if (!txnIndexExists.rows[0].exists) {
     await pgUserClient.query(userDBIndex);
   }
 


### PR DESCRIPTION
This PR fixes two issues:
- In migrate.ts, we skipped creating transaction outputs table if the schema exists. However, it's possible that the schema exists but the table doesn't. So we have to move table creation out of schema existence check.
- In both migrate.ts and user_database.ts, always check if a schema/table/index exists before running `CREATE IF NOT EXISTS` queries. The reason is that those DDL queries would hold locks and we don't want to always lock the table when we start a Transact program.