### PR TITLE
Allow proxy debug mode with undefined password

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -174,6 +174,7 @@ export class DBOSExecutor {
           const url = new URL(this.config.debugProxy!);
           this.config.poolConfig.host = url.hostname;
           this.config.poolConfig.port = parseInt(url.port, 10);
+          console.log(this.config)
           this.logger.info(`Debugging mode proxy: ${this.config.poolConfig.host}:${this.config.poolConfig.port}`);
         } catch (err) {
           this.logger.error(err);

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -169,7 +169,6 @@ export class DBOSExecutor {
 
     if (this.debugMode) {
       this.logger.info("Running in debug mode!");
-
       if (this.debugProxy) {
         try {
           const url = new URL(this.config.debugProxy!);

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -169,12 +169,12 @@ export class DBOSExecutor {
 
     if (this.debugMode) {
       this.logger.info("Running in debug mode!");
+
       if (this.debugProxy) {
         try {
           const url = new URL(this.config.debugProxy!);
           this.config.poolConfig.host = url.hostname;
           this.config.poolConfig.port = parseInt(url.port, 10);
-          console.log(this.config)
           this.logger.info(`Debugging mode proxy: ${this.config.poolConfig.host}:${this.config.poolConfig.port}`);
         } catch (err) {
           this.logger.error(err);

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -52,7 +52,7 @@ export interface ConfigFile {
 export function substituteEnvVars(content: string): string {
   const regex = /\${([^}]+)}/g; // Regex to match ${VAR_NAME} style placeholders
   return content.replace(regex, (_, g1: string) => {
-    return process.env[g1] || '""'; // If the env variable is not set, return an empty string.
+    return process.env[g1] || ""; // If the env variable is not set, return an empty string.
   });
 }
 
@@ -84,12 +84,8 @@ export function writeConfigFile(configFile: ConfigFile, configFilePath: string) 
   }
 }
 
-export function constructPoolConfig(configFile: ConfigFile, useProxy: boolean = false) {
-  if (!configFile.database) {
-    throw new DBOSInitializationError(`DBOS configuration (dbos-config.yaml) does not contain database config`);
-  }
-
-  const poolConfig: PoolConfig = {
+export function constructPoolConfig(configFile: ConfigFile) {
+   const poolConfig: PoolConfig = {
     host: configFile.database.hostname,
     port: configFile.database.port,
     user: configFile.database.username,
@@ -100,19 +96,6 @@ export function constructPoolConfig(configFile: ConfigFile, useProxy: boolean = 
 
   if (!poolConfig.database) {
     throw new DBOSInitializationError(`DBOS configuration (dbos-config.yaml) does not contain application database name`);
-  }
-
-  if (!poolConfig.password) {
-    if (useProxy) {
-      poolConfig.password = "PROXY-MODE"; // Assign a password if not set. We don't need password to authenticate with the local proxy.
-    } else {
-      const pgPassword: string | undefined = process.env.PGPASSWORD;
-      if (pgPassword) {
-        poolConfig.password = pgPassword;
-      } else {
-        throw new DBOSInitializationError(`DBOS configuration (dbos-config.yaml) does not contain database password`);
-      }
-    }
   }
 
   // Details on Postgres SSL/TLS modes: https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION
@@ -160,6 +143,25 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, useProxy: bool
     throw new DBOSInitializationError(`DBOS configuration file ${configFilePath} is empty`);
   }
 
+  // Database field must exist
+  if (!configFile.database) {
+    throw new DBOSInitializationError(`DBOS configuration (dbos-config.yaml) does not contain database config`);
+  }
+
+  // Check for the database password
+  if (!configFile.database.password) {
+    if (useProxy) {
+      configFile.database.password = "PROXY-MODE"; // Assign a password if not set. We don't need password to authenticate with the local proxy.
+    } else {
+      const pgPassword: string | undefined = process.env.PGPASSWORD;
+      if (pgPassword) {
+        configFile.database.password = pgPassword;
+      } else {
+        throw new DBOSInitializationError(`DBOS configuration (dbos-config.yaml) does not contain database password`);
+      }
+    }
+  }
+
   const validator = ajv.compile(dbosConfigSchema);
   if (!validator(configFile)) {
     const errorMessages = prettyPrintAjvErrors(validator);
@@ -172,7 +174,7 @@ export function parseConfigFile(cliOptions?: DBOSCLIStartOptions, useProxy: bool
   /* Handle user database config */
   /*******************************/
 
-  const poolConfig = constructPoolConfig(configFile, useProxy);
+  const poolConfig = constructPoolConfig(configFile);
 
   /***************************/
   /* Handle telemetry config */

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -52,7 +52,7 @@ export interface ConfigFile {
 export function substituteEnvVars(content: string): string {
   const regex = /\${([^}]+)}/g; // Regex to match ${VAR_NAME} style placeholders
   return content.replace(regex, (_, g1: string) => {
-    return process.env[g1] || ""; // If the env variable is not set, return an empty string.
+    return process.env[g1] || '""'; // If the env variable is not set, return an empty string.
   });
 }
 

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -328,30 +328,5 @@ describe("dbos-config", () => {
       expect(poolConfig.database).toBe("some DB");
       process.env.PGPASSWORD = dbPassword;
     });
-
-    test("parseConfigFile sets undefined env variable as empty string", async () => {
-      const localMockDBOSConfigYamlString = `
-        database:
-          hostname: 'some host'
-          port: 1234
-          username: 'some user'
-          password: \${PGPASSWORD}
-          app_db_name: 'some DB'
-        env:
-          RANDENV: \${SOMERANDOMENV}
-      `;
-      jest.restoreAllMocks();
-      jest.spyOn(utils, "readFileSync").mockReturnValue(localMockDBOSConfigYamlString);
-      const [dbosConfig, _]: [DBOSConfig, DBOSRuntimeConfig] = parseConfigFile(mockCLIOptions, false);
-
-      // Test pool config options
-      const poolConfig: PoolConfig = dbosConfig.poolConfig;
-      expect(poolConfig.host).toBe("some host");
-      expect(poolConfig.port).toBe(1234);
-      expect(poolConfig.user).toBe("some user");
-      expect(poolConfig.password).toBe("dbos"); // Env variable exists
-      expect(poolConfig.database).toBe("some DB");
-      expect(dbosConfig.env!["RANDENV"]).toBe(""); // Env variable set to empty string
-    });
   });
 });

--- a/tests/testing/debugger.test.ts
+++ b/tests/testing/debugger.test.ts
@@ -20,7 +20,7 @@ describe("debugger-test", () => {
   beforeAll(async () => {
     config = generateDBOSTestConfig();
     debugConfig = generateDBOSTestConfig(undefined, true);
-    debugProxyConfig = generateDBOSTestConfig(undefined, true, "localhost:5432");
+    debugProxyConfig = generateDBOSTestConfig(undefined, true, "postgresql://localhost:5432");
     username = config.poolConfig.user || "postgres";
     await setUpDBOSTestDb(config);
   });


### PR DESCRIPTION
This PR fixes an issue where the undefined `PGPASSWORD` env in `dbos-config.yaml` was parsed as `null` not an empty string. This makes schema validation failed (i.e., debug mode with undefined password) because `null` is not a `string` type. The fix is to move the check for database password in `parseConfigFile` and assign the password to `"PROXY-MODE"` if not set.

Tests:
- Added a test to make sure debug mode with a proxy allows undefined `PGPASSWORD`.
- Fixed a minor issue in test where the proxy url wasn't correct and caused the logger to print `: NaN` in tests.