### PR TITLE
Enable http HEAD on all GET endpoints

### DIFF
--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -363,6 +363,8 @@ async checkPortAvailability(port: number, host: string): Promise<void> {
           case APITypes.GET:
             router.get(ro.apiURL, wrappedHandler);
             dbosExec.logger.debug(`DBOS Server Registered GET ${ro.apiURL}`);
+            router.head(ro.apiURL, wrappedHandler);
+            dbosExec.logger.debug(`DBOS Server Registered HEAD ${ro.apiURL}`);
             break;
           case APITypes.POST:
             router.post(ro.apiURL, wrappedHandler);

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -362,9 +362,8 @@ async checkPortAvailability(port: number, host: string): Promise<void> {
         switch(ro.apiType) {
           case APITypes.GET:
             router.get(ro.apiURL, wrappedHandler);
-            dbosExec.logger.debug(`DBOS Server Registered GET ${ro.apiURL}`);
             router.head(ro.apiURL, wrappedHandler);
-            dbosExec.logger.debug(`DBOS Server Registered HEAD ${ro.apiURL}`);
+            dbosExec.logger.debug(`DBOS Server Registered GET/HEAD ${ro.apiURL}`);
             break;
           case APITypes.POST:
             router.post(ro.apiURL, wrappedHandler);

--- a/tests/httpServer/server.test.ts
+++ b/tests/httpServer/server.test.ts
@@ -58,6 +58,14 @@ describe("httpserver-tests", () => {
     expect(uuidValidate(requestID)).toBe(true);
   });
 
+  test("head-hello", async () => {
+    const headResponse = await request(testRuntime.getHandlersCallback()).head("/hello");
+    const getResponse = await request(testRuntime.getHandlersCallback()).get("/hello");
+    expect(getResponse.body.message).toBe("hello!");
+    expect(headResponse.headers['content-length']).toEqual(getResponse.headers['content-length'])
+    expect(headResponse.headers['content-type']).toEqual(getResponse.headers['content-type'])
+  });
+
   test("get-url", async () => {
     const requestID = "my-request-id";
     const response = await request(testRuntime.getHandlersCallback()).get("/hello/alice").set(RequestIDHeader, requestID);


### PR DESCRIPTION
One line of code did it.

BUT

I am not aware of the side effects that a HEAD request can have on `/greeting/alice` example 
so please advise on how to handle it.

```ts
class Greetings {
  // Other function implementations
    @Workflow()
    @GetApi("/greeting/:friend")
    static async GreetingWorkflow(ctxt: WorkflowContext, friend: string) {
        const noteContent = `Thank you for being awesome, ${friend}!`;
        await ctxt.invoke(Greetings).SendGreetingEmail(friend, noteContent);
        await ctxt.invoke(Greetings).InsertGreeting(friend, noteContent);
        ctxt.logger.info(`Greeting sent to ${friend}!`);
        return noteContent;
    }
}
```
Irrelevant but should not this be a PostApi since it changes the application state?