### PR TITLE
update templates to use exported parseConfigFile

### DIFF
--- a/packages/create/templates/hello-prisma/generate_env.js
+++ b/packages/create/templates/hello-prisma/generate_env.js
@@ -1,4 +1,4 @@
-const { parseConfigFile } = require('@dbos-inc/dbos-sdk/dist/src/dbos-runtime/config');
+const { parseConfigFile } = require('@dbos-inc/dbos-sdk');
 const fs = require('node:fs');
 const path = require('node:path');
 

--- a/packages/create/templates/hello-typeorm/datasource.ts
+++ b/packages/create/templates/hello-typeorm/datasource.ts
@@ -1,4 +1,4 @@
-import { parseConfigFile } from '@dbos-inc/dbos-sdk/dist/src/dbos-runtime/config';
+import { parseConfigFile } from '@dbos-inc/dbos-sdk';
 import { TlsOptions } from 'tls';
 import { DataSource } from "typeorm";
 

--- a/packages/create/templates/hello/knexfile.js
+++ b/packages/create/templates/hello/knexfile.js
@@ -1,5 +1,4 @@
-const { parseConfigFile } = require('@dbos-inc/dbos-sdk/dist/src/dbos-runtime/config');
-const { DBOSConfig } = require('@dbos-inc/dbos-sdk/dist/src/dbos-executor');
+const { parseConfigFile } = require('@dbos-inc/dbos-sdk');
 
 const [dbosConfig, ] = parseConfigFile();
 


### PR DESCRIPTION
Tested hello template by using current @dbos-inc/create command, updating generated knexfile.js to match the change in this PR and running `npx dbos migrate`. Still need to test typeorm and prisma templates