### PR TITLE
S3: Missing index.ts

### DIFF
--- a/packages/component-aws-s3/index.ts
+++ b/packages/component-aws-s3/index.ts
@@ -1,4 +1,6 @@
 export {
+    FileRecord,
+
     S3Config,
     S3Ops,
 } from './src/s3_utils'

--- a/packages/component-aws-s3/index.ts
+++ b/packages/component-aws-s3/index.ts
@@ -1,0 +1,4 @@
+export {
+    S3Config,
+    S3Ops,
+} from './src/s3_utils'


### PR DESCRIPTION
`index.ts` got missed in the first version of S3.