### PR TITLE
Workflow Introspection

### DIFF
--- a/schemas/system_db_schema.ts
+++ b/schemas/system_db_schema.ts
@@ -11,6 +11,7 @@ export interface workflow_status {
   authenticated_roles: string;  // Serialized list of roles.
   request: string;  // Serialized HTTPRequest
   executor_id: string;  // Set to "local" for local deployment, set to microVM ID for cloud deployment.
+  application_version: string;
 }
 
 export interface notifications {

--- a/src/foundationdb/fdb_system_database.ts
+++ b/src/foundationdb/fdb_system_database.ts
@@ -3,7 +3,7 @@
 import { deserializeError, serializeError } from "serialize-error";
 import { DBOSExecutor, DBOSNull, dbosNull } from "../dbos-executor";
 import { WorkflowStatusInternal, SystemDatabase } from "../system_database";
-import { StatusString, WorkflowStatus } from "../workflow";
+import { GetWorkflowsInput, GetWorkflowsOutput, StatusString, WorkflowStatus } from "../workflow";
 import * as fdb from "foundationdb";
 import { DuplicateWorkflowEventError, DBOSWorkflowConflictUUIDError } from "../error";
 import { NativeValue } from "foundationdb/dist/lib/native";
@@ -405,5 +405,9 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
   }
   setLastScheduledTime(_wfn: string, _invtime: number): Promise<number | null> {
     return Promise.resolve(null);
+  }
+
+  getWorkflows(_input: GetWorkflowsInput): Promise<GetWorkflowsOutput> {
+    throw new Error("Method not implemented.");
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,8 @@ export {
   WorkflowConfig,
   WorkflowHandle,
   StatusString,
+  GetWorkflowsInput,
+  GetWorkflowsOutput,
 } from './workflow';
 
 export {

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -738,6 +738,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
       query = query.where('status', input.Status);
     }
     const rows = await query.select('workflow_uuid');
+    await knexDB.destroy();
     const workflowUUIDs = rows.map(row => row.workflow_uuid);
     return {
       workflowUUIDs: workflowUUIDs

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -733,10 +733,10 @@ export class PostgresSystemDatabase implements SystemDatabase {
       query = query.where('authenticated_user', input.authenticatedUser);
     }
     if (input.startTime) {
-      query = query.where('created_at', '>=', input.startTime.getTime());
+      query = query.where('created_at', '>=', new Date(input.startTime).getTime());
     }
     if (input.endTime) {
-      query = query.where('created_at', '<=', input.endTime.getTime());
+      query = query.where('created_at', '<=', new Date(input.endTime).getTime());
     }
     if (input.Status) {
       query = query.where('status', input.Status);

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -738,8 +738,8 @@ export class PostgresSystemDatabase implements SystemDatabase {
     if (input.endTime) {
       query = query.where('created_at', '<=', new Date(input.endTime).getTime());
     }
-    if (input.Status) {
-      query = query.where('status', input.Status);
+    if (input.status) {
+      query = query.where('status', input.status);
     }
     const rows = await query.select('workflow_uuid');
     const workflowUUIDs = rows.map(row => row.workflow_uuid);

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -741,6 +741,9 @@ export class PostgresSystemDatabase implements SystemDatabase {
     if (input.status) {
       query = query.where('status', input.status);
     }
+    if (input.applicationVersion) {
+      query = query.where('application_version', input.applicationVersion);
+    }
     const rows = await query.select('workflow_uuid');
     const workflowUUIDs = rows.map(row => row.workflow_uuid);
     return {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -64,7 +64,7 @@ export interface GetWorkflowsInput {
   authenticatedUser?: string;
   startTime?: string; // In RFC 3339 format
   endTime?: string; // In RFC 3339 format
-  status?: typeof StatusString[keyof typeof StatusString]; // "PENDING" | "SUCCESS" | "ERROR"
+  status?: "PENDING" | "SUCCESS" | "ERROR";
   applicationVersion?: string;
 }
 

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -59,6 +59,18 @@ export interface WorkflowStatus {
   readonly request: HTTPRequest; // The parent request for this workflow, if any.
 }
 
+export interface GetWorkflowsInput {
+  workflowName?: string;
+  authenticatedUser?: string;
+  startTime?: Date;
+  endTime?: Date;
+  Status?: typeof StatusString[keyof typeof StatusString]; // "PENDING" | "SUCCESS" | "ERROR"
+}
+
+export interface GetWorkflowsOutput {
+  workflowUUIDs: string[];
+}
+
 export interface PgTransactionId {
   txid: string;
 }

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -62,8 +62,8 @@ export interface WorkflowStatus {
 export interface GetWorkflowsInput {
   workflowName?: string;
   authenticatedUser?: string;
-  startTime?: Date;
-  endTime?: Date;
+  startTime?: string; // In RFC 3339 format
+  endTime?: string; // In RFC 3339 format
   Status?: typeof StatusString[keyof typeof StatusString]; // "PENDING" | "SUCCESS" | "ERROR"
 }
 

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -64,7 +64,7 @@ export interface GetWorkflowsInput {
   authenticatedUser?: string;
   startTime?: string; // In RFC 3339 format
   endTime?: string; // In RFC 3339 format
-  Status?: typeof StatusString[keyof typeof StatusString]; // "PENDING" | "SUCCESS" | "ERROR"
+  status?: typeof StatusString[keyof typeof StatusString]; // "PENDING" | "SUCCESS" | "ERROR"
 }
 
 export interface GetWorkflowsOutput {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -60,11 +60,12 @@ export interface WorkflowStatus {
 }
 
 export interface GetWorkflowsInput {
-  workflowName?: string;
+  workflowName?: string; // The name of the workflow function
   authenticatedUser?: string;
   startTime?: string; // In RFC 3339 format
   endTime?: string; // In RFC 3339 format
   status?: typeof StatusString[keyof typeof StatusString]; // "PENDING" | "SUCCESS" | "ERROR"
+  applicationVersion?: string;
 }
 
 export interface GetWorkflowsOutput {

--- a/tests/httpServer/server.test.ts
+++ b/tests/httpServer/server.test.ts
@@ -385,7 +385,7 @@ describe("httpserver-tests", () => {
 
     @PostApi("/transaction/:name")
     @Transaction()
-    static async testTranscation(txnCtxt: TestTransactionContext, name: string) {
+    static async testTransaction(txnCtxt: TestTransactionContext, name: string) {
       const { rows } = await txnCtxt.client.query<TestKvTable>(`INSERT INTO ${testTableName}(id, value) VALUES (1, $1) RETURNING id`, [name]);
       return `hello ${rows[0].id}`;
     }
@@ -399,7 +399,7 @@ describe("httpserver-tests", () => {
     @PostApi("/workflow")
     @Workflow()
     static async testWorkflow(wfCtxt: WorkflowContext, @ArgSource(ArgSources.QUERY) name: string) {
-      const res = await wfCtxt.invoke(TestEndpoints).testTranscation(name);
+      const res = await wfCtxt.invoke(TestEndpoints).testTransaction(name);
       return wfCtxt.invoke(TestEndpoints).testCommunicator(res);
     }
 
@@ -407,8 +407,8 @@ describe("httpserver-tests", () => {
     @Workflow()
     static async testWorkflowError(wfCtxt: WorkflowContext, name: string) {
       // This workflow should encounter duplicate primary key error.
-      let res = await wfCtxt.invoke(TestEndpoints).testTranscation(name);
-      res = await wfCtxt.invoke(TestEndpoints).testTranscation(name);
+      let res = await wfCtxt.invoke(TestEndpoints).testTransaction(name);
+      res = await wfCtxt.invoke(TestEndpoints).testTransaction(name);
       return res;
     }
 

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -1,0 +1,60 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import {
+  Workflow,
+  GetApi,
+  HandlerContext,
+  PostApi,
+  WorkflowContext,
+} from "../src";
+import request from "supertest";
+import { DBOSConfig } from "../src/dbos-executor";
+import { TestingRuntime, createInternalTestRuntime } from "../src/testing/testing_runtime";
+import { generateDBOSTestConfig, setUpDBOSTestDb } from "./helpers";
+import { GetWorkflowsOutput } from "../src/workflow";
+
+describe("workflow-management-tests", () => {
+  const testTableName = "dbos_test_kv";
+
+  let testRuntime: TestingRuntime;
+  let config: DBOSConfig;
+
+  beforeAll(async () => {
+    config = generateDBOSTestConfig();
+    await setUpDBOSTestDb(config);
+  });
+
+  beforeEach(async () => {
+    testRuntime = await createInternalTestRuntime([TestEndpoints], config);
+    await testRuntime.queryUserDB(`DROP TABLE IF EXISTS ${testTableName};`);
+    await testRuntime.queryUserDB(`CREATE TABLE IF NOT EXISTS ${testTableName} (id INT PRIMARY KEY, value TEXT);`);
+  });
+
+  afterEach(async () => {
+    await testRuntime.destroy();
+  });
+
+  test("simple-getworkflows", async () => {
+    let response = await request(testRuntime.getHandlersCallback()).post("/workflow/alice");
+    expect(response.statusCode).toBe(200);
+    expect(response.text).toBe("alice");
+
+    response = await request(testRuntime.getHandlersCallback()).get("/getWorkflows");
+    expect(response.statusCode).toBe(200);
+    const workflowUUIDs = JSON.parse(response.text) as GetWorkflowsOutput;
+    expect(workflowUUIDs.workflowUUIDs.length).toBe(1);
+  });
+
+
+  class TestEndpoints {
+    @PostApi("/workflow/:name")
+    @Workflow()
+    static async testWorkflow(_ctxt: WorkflowContext, name: string) {
+      return Promise.resolve(name);
+    }
+
+    @GetApi("/getWorkflows")
+    static async getWorkflows(ctxt: HandlerContext) {
+      return await ctxt.getWorkflows({});
+    }
+  }
+});

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import {
   Workflow,
   HandlerContext,

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -83,6 +83,20 @@ describe("workflow-management-tests", () => {
     expect(workflowUUIDs.workflowUUIDs.length).toBe(0);
   });
 
+  test("getworkflows-with-wfname", async () => {
+    let response = await request(testRuntime.getHandlersCallback()).post("/workflow/alice");
+    expect(response.statusCode).toBe(200);
+    expect(response.text).toBe("alice");
+
+    const input: GetWorkflowsInput = {
+      workflowName: "testWorkflow"
+    }
+    response = await request(testRuntime.getHandlersCallback()).post("/getWorkflows").send({input});
+    expect(response.statusCode).toBe(200);
+    const workflowUUIDs = JSON.parse(response.text) as GetWorkflowsOutput;
+    expect(workflowUUIDs.workflowUUIDs.length).toBe(1);
+  });
+
   class TestEndpoints {
     @PostApi("/workflow/:name")
     @Workflow()


### PR DESCRIPTION
This PR introduces a new `getWorkflows()` method allowing users to query the statuses of their workflows. For now, this is a method of `HandlerContext`.

This method takes in the following input:

```typescript
export interface GetWorkflowsInput {
  workflowName?: string; // The name of the workflow function
  authenticatedUser?: string;
  startTime?: string; // In RFC 3339 format
  endTime?: string; // In RFC 3339 format
  status?: "PENDING" | "SUCCESS" | "ERROR";
  applicationVersion?: string;
}
```

It returns a list of the UUIDs of all workflows that satisfy all the constraints specified in the input.

For example, to find the UUIDs of all executions of `testWorkflow` that errored, run:

`getWorkflows({workflowName: "testWorkflow", status: StatusString.Error})`

You can then call `retrieveWorkflow` on the retrieved UUID to obtain more information about those specific workflows.