### PR TITLE
Retrieve Workflow Inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "lint": "eslint --ignore-pattern src/foundationdb/ --ignore-pattern tests/foundationdb/ .",
     "lint-fdb": "eslint .",
     "setversion": "npm run --workspaces setversion && grunt setversion",
-    "test": "npm run build && npm run --workspaces test && npx prisma generate --schema tests/prisma/schema.prisma && jest --coverage --collectCoverageFrom='src/**/*' --collectCoverageFrom='!src/foundationdb/**/*' --detectOpenHandles --testPathIgnorePatterns=examples/* --testPathIgnorePatterns=packages/* --testPathIgnorePatterns=tests/foundationdb/*",
-    "test-fdb": "npm run build-fdb && npm run --workspaces test && npx prisma generate --schema tests/prisma/schema.prisma && jest --runInBand --coverage"
+    "test": "npm run build && rm -rf packages/create/templates/hello-prisma/node_modules/ && npm run --workspaces test && npx prisma generate --schema tests/prisma/schema.prisma && jest --coverage --collectCoverageFrom='src/**/*' --collectCoverageFrom='!src/foundationdb/**/*' --detectOpenHandles --testPathIgnorePatterns=examples/* --testPathIgnorePatterns=packages/* --testPathIgnorePatterns=tests/foundationdb/*",
+    "test-fdb": "npm run build-fdb && rm -rf packages/create/templates/hello-prisma/node_modules/ && npm run --workspaces test && npx prisma generate --schema tests/prisma/schema.prisma && jest --runInBand --coverage"
   },
   "bin": {
     "dbos": "./dist/src/dbos-runtime/cli.js",

--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -356,4 +356,8 @@ class RetrievedHandleDebug<R> implements WorkflowHandle<R> {
   async getResult(): Promise<R> {
     return await this.systemDatabase.getWorkflowResult<R>(this.workflowUUID);
   }
+
+  async getWorkflowInputs<T extends any[]>(): Promise<T> {
+    return await this.systemDatabase.getWorkflowInputs<T>(this.workflowUUID) as T;
+  }
 }

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -725,7 +725,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
   }
 
   async getWorkflows(input: GetWorkflowsInput): Promise<GetWorkflowsOutput> {
-    let query = this.knexDB<{workflow_uuid: string}>(`${DBOSExecutor.systemDBSchemaName}.workflow_status`);
+    let query = this.knexDB<{workflow_uuid: string}>(`${DBOSExecutor.systemDBSchemaName}.workflow_status`).orderBy('created_at', 'desc');
     if (input.workflowName) {
       query = query.where('name', input.workflowName);
     }
@@ -743,6 +743,9 @@ export class PostgresSystemDatabase implements SystemDatabase {
     }
     if (input.applicationVersion) {
       query = query.where('application_version', input.applicationVersion);
+    }
+    if (input.limit) {
+      query = query.limit(input.limit);
     }
     const rows = await query.select('workflow_uuid');
     const workflowUUIDs = rows.map(row => row.workflow_uuid);

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -61,11 +61,12 @@ export interface WorkflowStatus {
 
 export interface GetWorkflowsInput {
   workflowName?: string; // The name of the workflow function
-  authenticatedUser?: string;
-  startTime?: string; // In RFC 3339 format
-  endTime?: string; // In RFC 3339 format
-  status?: "PENDING" | "SUCCESS" | "ERROR";
-  applicationVersion?: string;
+  authenticatedUser?: string; // The user who ran the workflow.
+  startTime?: string; // Timestamp in RFC 3339 format
+  endTime?: string; // Timestamp in RFC 3339 format
+  status?: "PENDING" | "SUCCESS" | "ERROR"; // The status of the workflow.
+  applicationVersion?: string; // The application version that ran this workflow.
+  limit?: number; // Return up to this many workflows IDs. IDs are ordered by recency.
 }
 
 export interface GetWorkflowsOutput {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -66,7 +66,7 @@ export interface GetWorkflowsInput {
   endTime?: string; // Timestamp in RFC 3339 format
   status?: "PENDING" | "SUCCESS" | "ERROR"; // The status of the workflow.
   applicationVersion?: string; // The application version that ran this workflow.
-  limit?: number; // Return up to this many workflows IDs. IDs are ordered by recency.
+  limit?: number; // Return up to this many workflows IDs. IDs are ordered by workflow creation time.
 }
 
 export interface GetWorkflowsOutput {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -708,6 +708,10 @@ export interface WorkflowHandle<R> {
    * Return the workflow's UUID.
    */
   getWorkflowUUID(): string;
+  /**
+   * Return the workflow's inputs
+   */
+  getWorkflowInputs<T extends any[]>(): Promise<T>
 }
 
 /**
@@ -728,6 +732,10 @@ export class InvokedHandle<R> implements WorkflowHandle<R> {
   async getResult(): Promise<R> {
     return this.workflowPromise;
   }
+
+  async getWorkflowInputs<T extends any[]>(): Promise<T> {
+    return await this.systemDatabase.getWorkflowInputs<T>(this.workflowUUID) as T;
+  }
 }
 
 /**
@@ -746,5 +754,9 @@ export class RetrievedHandle<R> implements WorkflowHandle<R> {
 
   async getResult(): Promise<R> {
     return await this.systemDatabase.getWorkflowResult<R>(this.workflowUUID);
+  }
+
+  async getWorkflowInputs<T extends any[]>(): Promise<T> {
+    return await this.systemDatabase.getWorkflowInputs<T>(this.workflowUUID) as T;
   }
 }

--- a/tests/dbos.test.ts
+++ b/tests/dbos.test.ts
@@ -196,6 +196,7 @@ describe("dbos-tests", () => {
       status: StatusString.PENDING,
       workflowName: RetrieveWorkflowStatus.testStatusWorkflow.name,
     });
+    await expect(workflowHandle.getWorkflowInputs()).resolves.toMatchObject([123, "hello"])
 
     RetrieveWorkflowStatus.resolve1();
     await RetrieveWorkflowStatus.promise3;

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -141,19 +141,32 @@ describe("workflow-management-tests", () => {
   });
 
   test("getworkflows-with-limit", async () => {
+
+    let response = await request(testRuntime.getHandlersCallback()).post("/workflow/alice");
+    expect(response.statusCode).toBe(200);
+    expect(response.text).toBe("alice");
+
+    const input: GetWorkflowsInput = {
+      limit: 10
+    }
+
+    response = await request(testRuntime.getHandlersCallback()).post("/getWorkflows").send({input});
+    expect(response.statusCode).toBe(200);
+    let workflowUUIDs = JSON.parse(response.text) as GetWorkflowsOutput;
+    expect(workflowUUIDs.workflowUUIDs.length).toBe(1);
+    const firstUUID = workflowUUIDs.workflowUUIDs[0];
+
     for (let i = 0 ; i < 10; i++) {
-      const response = await request(testRuntime.getHandlersCallback()).post("/workflow/alice");
+      response = await request(testRuntime.getHandlersCallback()).post("/workflow/alice");
       expect(response.statusCode).toBe(200);
       expect(response.text).toBe("alice");
     }
 
-    const input: GetWorkflowsInput = {
-      authenticatedUser: "alice"
-    }
-    const response = await request(testRuntime.getHandlersCallback()).post("/getWorkflows").send({input});
+    response = await request(testRuntime.getHandlersCallback()).post("/getWorkflows").send({input});
     expect(response.statusCode).toBe(200);
-    const workflowUUIDs = JSON.parse(response.text) as GetWorkflowsOutput;
+    workflowUUIDs = JSON.parse(response.text) as GetWorkflowsOutput;
     expect(workflowUUIDs.workflowUUIDs.length).toBe(10);
+    expect(workflowUUIDs.workflowUUIDs).not.toContain(firstUUID);
   });
 
   async function testAuthMiddleware(_ctx: MiddlewareContext) {

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -140,6 +140,22 @@ describe("workflow-management-tests", () => {
     expect(workflowUUIDs.workflowUUIDs.length).toBe(0);
   });
 
+  test("getworkflows-with-limit", async () => {
+    for (let i = 0 ; i < 10; i++) {
+      const response = await request(testRuntime.getHandlersCallback()).post("/workflow/alice");
+      expect(response.statusCode).toBe(200);
+      expect(response.text).toBe("alice");
+    }
+
+    const input: GetWorkflowsInput = {
+      authenticatedUser: "alice"
+    }
+    const response = await request(testRuntime.getHandlersCallback()).post("/getWorkflows").send({input});
+    expect(response.statusCode).toBe(200);
+    const workflowUUIDs = JSON.parse(response.text) as GetWorkflowsOutput;
+    expect(workflowUUIDs.workflowUUIDs.length).toBe(10);
+  });
+
   async function testAuthMiddleware(_ctx: MiddlewareContext) {
     return Promise.resolve({
       authenticatedUser: "alice",


### PR DESCRIPTION
- Make it possible to retrieve a workflow's input from its workflow handle.
- Add a `limit` argument to `getWorkflows()`