### PR TITLE
Dead Letter Queue

### DIFF
--- a/migrations/20240621000000_workflow_tries.js
+++ b/migrations/20240621000000_workflow_tries.js
@@ -1,0 +1,15 @@
+exports.up = function(knex) {
+    return knex.schema.withSchema('dbos')
+        .table('workflow_status', function(table) {
+
+            table.bigInteger('workflow_retries')
+                .defaultTo(0);
+        });
+};
+
+exports.down = function(knex) {
+    return knex.schema.withSchema('dbos')
+        .table('workflow_status', function(table) {
+            table.dropColumn('workflow_retries');
+        });
+};

--- a/migrations/20240621000000_workflow_tries.js
+++ b/migrations/20240621000000_workflow_tries.js
@@ -2,7 +2,7 @@ exports.up = function(knex) {
     return knex.schema.withSchema('dbos')
         .table('workflow_status', function(table) {
 
-            table.bigInteger('workflow_retries')
+            table.bigInteger('recovery_attempts')
                 .defaultTo(0);
         });
 };
@@ -10,6 +10,6 @@ exports.up = function(knex) {
 exports.down = function(knex) {
     return knex.schema.withSchema('dbos')
         .table('workflow_status', function(table) {
-            table.dropColumn('workflow_retries');
+            table.dropColumn('recovery_attempts');
         });
 };

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -514,7 +514,7 @@ export class DBOSExecutor {
       applicationVersion: wCtxt.applicationVersion,
       applicationID: wCtxt.applicationID,
       createdAt: Date.now(), // Remember the start time of this workflow
-      maxRetries: 50,
+      maxRetries: wCtxt.maxRecoveryAttempts,
     };
 
     if (wCtxt.isTempWorkflow) {

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -514,6 +514,7 @@ export class DBOSExecutor {
       applicationVersion: wCtxt.applicationVersion,
       applicationID: wCtxt.applicationID,
       createdAt: Date.now(), // Remember the start time of this workflow
+      maxRetries: 50,
     };
 
     if (wCtxt.isTempWorkflow) {

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -515,6 +515,7 @@ export class DBOSExecutor {
       applicationID: wCtxt.applicationID,
       createdAt: Date.now(), // Remember the start time of this workflow
       maxRetries: wCtxt.maxRecoveryAttempts,
+      recovery: params.recovery === true,
     };
 
     if (wCtxt.isTempWorkflow) {
@@ -730,7 +731,7 @@ export class DBOSExecutor {
 
     if (wfInfo) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      return this.workflow(wfInfo.workflow, { workflowUUID: workflowUUID, parentCtx: parentCtx, configuredInstance: configuredInst }, ...inputs);
+      return this.workflow(wfInfo.workflow, { workflowUUID: workflowUUID, parentCtx: parentCtx, configuredInstance: configuredInst, recovery: true }, ...inputs);
     }
 
     // Should be temporary workflows. Parse the name of the workflow.
@@ -775,7 +776,7 @@ export class DBOSExecutor {
       throw new DBOSNotRegisteredError(wfName);
     }
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    return this.workflow(temp_workflow, { workflowUUID: workflowUUID, parentCtx: parentCtx ?? undefined, configuredInstance: clsinst}, ...inputs);
+    return this.workflow(temp_workflow, { workflowUUID: workflowUUID, parentCtx: parentCtx ?? undefined, configuredInstance: clsinst, recovery: true}, ...inputs);
   }
 
   // NOTE: this creates a new span, it does not inherit the span from the original workflow

--- a/src/error.ts
+++ b/src/error.ts
@@ -174,3 +174,10 @@ export class DBOSFailLoadOperationsError extends DBOSError {
     super(msg, FailLoadOperationsError);
   }
 }
+
+const DeadLetterQueueError = 18;
+export class DBOSDeadLetterQueueError extends DBOSError {
+  constructor(workflowUUID: string, maxRetries: number) {
+    super(`Workflow ${workflowUUID} has been moved to the dead-letter queue after exceeding the maximum of ${maxRetries} retries`, DeadLetterQueueError);
+  }
+}

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -67,7 +67,8 @@ export interface WorkflowStatusInternal {
   applicationVersion: string;
   applicationID: string;
   createdAt: number;
-  maxRetries: number
+  maxRetries: number;
+  recovery: boolean;
 }
 
 export interface ExistenceCheck {
@@ -189,11 +190,11 @@ export class PostgresSystemDatabase implements SystemDatabase {
         initStatus.applicationVersion,
         initStatus.applicationID,
         initStatus.createdAt,
-        true,
+        initStatus.recovery,
       ]
     );
     const workflow_retries = result.rows[0].workflow_retries;
-    if (workflow_retries >= initStatus.maxRetries) {
+    if (workflow_retries >= initStatus.maxRetries && initStatus.recovery) {
       throw new DBOSDeadLetterQueueError(initStatus.workflowUUID, initStatus.maxRetries);
     }
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -193,7 +193,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
       ]
     );
     const workflow_retries = result.rows[0].workflow_retries;
-    if (workflow_retries > initStatus.maxRetries) {
+    if (workflow_retries >= initStatus.maxRetries) {
       throw new DBOSDeadLetterQueueError(initStatus.workflowUUID, initStatus.maxRetries);
     }
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -195,7 +195,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     );
     const recovery_attempts = result.rows[0].recovery_attempts;
     if (recovery_attempts >= initStatus.maxRetries && initStatus.recovery) {
-      await this.pool.query(`UPDATE ${DBOSExecutor.systemDBSchemaName}.workflow_status SET status=$1 WHERE workflow_uuid=$2 AND status=$3`, [StatusString.DEADLETTER, initStatus.workflowUUID, StatusString.PENDING]);
+      await this.pool.query(`UPDATE ${DBOSExecutor.systemDBSchemaName}.workflow_status SET status=$1 WHERE workflow_uuid=$2 AND status=$3`, [StatusString.NORETRY, initStatus.workflowUUID, StatusString.PENDING]);
       throw new DBOSDeadLetterQueueError(initStatus.workflowUUID, initStatus.maxRetries);
     }
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -195,7 +195,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     );
     const recovery_attempts = result.rows[0].recovery_attempts;
     if (recovery_attempts >= initStatus.maxRetries && initStatus.recovery) {
-      await this.pool.query(`UPDATE ${DBOSExecutor.systemDBSchemaName}.workflow_status SET status=$1 WHERE workflow_uuid=$2 AND status=$3`, [StatusString.NORETRY, initStatus.workflowUUID, StatusString.PENDING]);
+      await this.pool.query(`UPDATE ${DBOSExecutor.systemDBSchemaName}.workflow_status SET status=$1 WHERE workflow_uuid=$2 AND status=$3`, [StatusString.RETRY_EXCEEDED, initStatus.workflowUUID, StatusString.PENDING]);
       throw new DBOSDeadLetterQueueError(initStatus.workflowUUID, initStatus.maxRetries);
     }
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -195,6 +195,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     );
     const workflow_retries = result.rows[0].workflow_retries;
     if (workflow_retries >= initStatus.maxRetries && initStatus.recovery) {
+      await this.pool.query(`UPDATE ${DBOSExecutor.systemDBSchemaName}.workflow_status SET status=$1 WHERE workflow_uuid=$2 AND status=$3`, [StatusString.DEADLETTER, initStatus.workflowUUID, StatusString.PENDING]);
       throw new DBOSDeadLetterQueueError(initStatus.workflowUUID, initStatus.maxRetries);
     }
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -195,7 +195,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     );
     const recovery_attempts = result.rows[0].recovery_attempts;
     if (recovery_attempts >= initStatus.maxRetries && initStatus.recovery) {
-      await this.pool.query(`UPDATE ${DBOSExecutor.systemDBSchemaName}.workflow_status SET status=$1 WHERE workflow_uuid=$2 AND status=$3`, [StatusString.RETRY_EXCEEDED, initStatus.workflowUUID, StatusString.PENDING]);
+      await this.pool.query(`UPDATE ${DBOSExecutor.systemDBSchemaName}.workflow_status SET status=$1 WHERE workflow_uuid=$2 AND status=$3`, [StatusString.RETRIES_EXCEEDED, initStatus.workflowUUID, StatusString.PENDING]);
       throw new DBOSDeadLetterQueueError(initStatus.workflowUUID, initStatus.maxRetries);
     }
 

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -65,7 +65,7 @@ export interface GetWorkflowsInput {
   authenticatedUser?: string; // The user who ran the workflow.
   startTime?: string; // Timestamp in RFC 3339 format
   endTime?: string; // Timestamp in RFC 3339 format
-  status?: "PENDING" | "SUCCESS" | "ERROR" | "RETRY_EXCEEDED"; // The status of the workflow.
+  status?: "PENDING" | "SUCCESS" | "ERROR" | "RETRIES_EXCEEDED"; // The status of the workflow.
   applicationVersion?: string; // The application version that ran this workflow.
   limit?: number; // Return up to this many workflows IDs. IDs are ordered by workflow creation time.
 }
@@ -88,7 +88,7 @@ export const StatusString = {
   PENDING: "PENDING",
   SUCCESS: "SUCCESS",
   ERROR: "ERROR",
-  RETRY_EXCEEDED: "RETRY_EXCEEDED",
+  RETRIES_EXCEEDED: "RETRIES_EXCEEDED",
 } as const;
 
 type WFFunc = (ctxt: WorkflowContext, ...args: any[]) => Promise<unknown>;

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -42,6 +42,7 @@ export interface WorkflowParams {
   workflowUUID?: string;
   parentCtx?: DBOSContextImpl;
   configuredInstance?: ConfiguredInstance | null;
+  recovery?: boolean;
 }
 
 export interface WorkflowConfig {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -65,7 +65,7 @@ export interface GetWorkflowsInput {
   authenticatedUser?: string; // The user who ran the workflow.
   startTime?: string; // Timestamp in RFC 3339 format
   endTime?: string; // Timestamp in RFC 3339 format
-  status?: "PENDING" | "SUCCESS" | "ERROR"; // The status of the workflow.
+  status?: "PENDING" | "SUCCESS" | "ERROR" | "DEADLETTER"; // The status of the workflow.
   applicationVersion?: string; // The application version that ran this workflow.
   limit?: number; // Return up to this many workflows IDs. IDs are ordered by workflow creation time.
 }
@@ -88,6 +88,7 @@ export const StatusString = {
   PENDING: "PENDING",
   SUCCESS: "SUCCESS",
   ERROR: "ERROR",
+  DEADLETTER: "DEADLETTER",
 } as const;
 
 type WFFunc = (ctxt: WorkflowContext, ...args: any[]) => Promise<unknown>;

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -65,7 +65,7 @@ export interface GetWorkflowsInput {
   authenticatedUser?: string; // The user who ran the workflow.
   startTime?: string; // Timestamp in RFC 3339 format
   endTime?: string; // Timestamp in RFC 3339 format
-  status?: "PENDING" | "SUCCESS" | "ERROR" | "DEADLETTER"; // The status of the workflow.
+  status?: "PENDING" | "SUCCESS" | "ERROR" | "NORETRY"; // The status of the workflow.
   applicationVersion?: string; // The application version that ran this workflow.
   limit?: number; // Return up to this many workflows IDs. IDs are ordered by workflow creation time.
 }
@@ -88,7 +88,7 @@ export const StatusString = {
   PENDING: "PENDING",
   SUCCESS: "SUCCESS",
   ERROR: "ERROR",
-  DEADLETTER: "DEADLETTER",
+  NORETRY: "NORETRY",
 } as const;
 
 type WFFunc = (ctxt: WorkflowContext, ...args: any[]) => Promise<unknown>;

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -44,8 +44,8 @@ export interface WorkflowParams {
   configuredInstance?: ConfiguredInstance | null;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface WorkflowConfig {
+  maxRecoveryAttempts?: number;
 }
 
 export interface WorkflowStatus {
@@ -147,6 +147,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
   readonly #dbosExec;
   readonly resultBuffer: Map<number, BufferedResult> = new Map<number, BufferedResult>();
   readonly isTempWorkflow: boolean;
+  readonly maxRecoveryAttempts;
 
   constructor(
     dbosExec: DBOSExecutor,
@@ -176,6 +177,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
     this.#dbosExec = dbosExec;
     this.isTempWorkflow = DBOSExecutor.tempWorkflowName === workflowName;
     this.applicationConfig = dbosExec.config.application;
+    this.maxRecoveryAttempts = workflowConfig.maxRecoveryAttempts ? workflowConfig.maxRecoveryAttempts : 50;
   }
 
   functionIDGetIncrement(): number {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -65,7 +65,7 @@ export interface GetWorkflowsInput {
   authenticatedUser?: string; // The user who ran the workflow.
   startTime?: string; // Timestamp in RFC 3339 format
   endTime?: string; // Timestamp in RFC 3339 format
-  status?: "PENDING" | "SUCCESS" | "ERROR" | "NORETRY"; // The status of the workflow.
+  status?: "PENDING" | "SUCCESS" | "ERROR" | "RETRY_EXCEEDED"; // The status of the workflow.
   applicationVersion?: string; // The application version that ran this workflow.
   limit?: number; // Return up to this many workflows IDs. IDs are ordered by workflow creation time.
 }
@@ -88,7 +88,7 @@ export const StatusString = {
   PENDING: "PENDING",
   SUCCESS: "SUCCESS",
   ERROR: "ERROR",
-  NORETRY: "NORETRY",
+  RETRY_EXCEEDED: "RETRY_EXCEEDED",
 } as const;
 
 type WFFunc = (ctxt: WorkflowContext, ...args: any[]) => Promise<unknown>;

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -98,8 +98,8 @@ describe("recovery-tests", () => {
       expect(LocalRecovery.recoveryCount).toBe(i + LocalRecovery.maxRecoveryAttempts + 1);
     }
 
-    const { rows } = await systemDBClient.query<{status: string, workflow_retries: number}>(`SELECT status, workflow_retries FROM dbos.workflow_status WHERE workflow_uuid=$1`, [handle.getWorkflowUUID()]);
-    expect(rows[0].workflow_retries).toBe(String(LocalRecovery.maxRecoveryAttempts));
+    const { rows } = await systemDBClient.query<{status: string, recovery_attempts: number}>(`SELECT status, recovery_attempts FROM dbos.workflow_status WHERE workflow_uuid=$1`, [handle.getWorkflowUUID()]);
+    expect(rows[0].recovery_attempts).toBe(String(LocalRecovery.maxRecoveryAttempts));
     expect(rows[0].status).toBe(StatusString.DEADLETTER);
 
     LocalRecovery.deadLetterResolve();

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -100,14 +100,14 @@ describe("recovery-tests", () => {
 
     let result = await systemDBClient.query<{status: string, recovery_attempts: number}>(`SELECT status, recovery_attempts FROM dbos.workflow_status WHERE workflow_uuid=$1`, [handle.getWorkflowUUID()]);
     expect(result.rows[0].recovery_attempts).toBe(String(LocalRecovery.maxRecoveryAttempts));
-    expect(result.rows[0].status).toBe(StatusString.RETRY_EXCEEDED);
+    expect(result.rows[0].status).toBe(StatusString.RETRIES_EXCEEDED);
 
     LocalRecovery.deadLetterResolve();
 
     await dbosExec.flushWorkflowResultBuffer();
     result = await systemDBClient.query<{status: string, recovery_attempts: number}>(`SELECT status, recovery_attempts FROM dbos.workflow_status WHERE workflow_uuid=$1`, [handle.getWorkflowUUID()]);
     expect(result.rows[0].recovery_attempts).toBe(String(LocalRecovery.maxRecoveryAttempts));
-    expect(result.rows[0].status).toBe(StatusString.RETRY_EXCEEDED);
+    expect(result.rows[0].status).toBe(StatusString.RETRIES_EXCEEDED);
   });
 
   test("local-recovery", async () => {

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -100,7 +100,7 @@ describe("recovery-tests", () => {
 
     const { rows } = await systemDBClient.query<{status: string, recovery_attempts: number}>(`SELECT status, recovery_attempts FROM dbos.workflow_status WHERE workflow_uuid=$1`, [handle.getWorkflowUUID()]);
     expect(rows[0].recovery_attempts).toBe(String(LocalRecovery.maxRecoveryAttempts));
-    expect(rows[0].status).toBe(StatusString.DEADLETTER);
+    expect(rows[0].status).toBe(StatusString.NORETRY);
 
     LocalRecovery.deadLetterResolve();
   });

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -76,7 +76,10 @@ describe("recovery-tests", () => {
       expect(LocalRecovery.recoveryCount).toBeLessThanOrEqual(LocalRecovery.maxRecoveryAttempts);
     }
 
-    console.log(handle.getWorkflowUUID());
+    for (let i = 0; i < LocalRecovery.maxRecoveryAttempts * 2; i++) {
+      await testRuntime.startWorkflow(LocalRecovery, handle.getWorkflowUUID()).doomedWorkflow();
+      expect(LocalRecovery.recoveryCount).toBe(i + LocalRecovery.maxRecoveryAttempts + 1);
+    }
   });
 
   test("local-recovery", async () => {

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -103,11 +103,12 @@ describe("recovery-tests", () => {
     expect(result.rows[0].status).toBe(StatusString.RETRIES_EXCEEDED);
 
     LocalRecovery.deadLetterResolve();
+    await handle.getResult();
 
-    await dbosExec.flushWorkflowResultBuffer();
+    await dbosExec.flushWorkflowBuffers();
     result = await systemDBClient.query<{status: string, recovery_attempts: number}>(`SELECT status, recovery_attempts FROM dbos.workflow_status WHERE workflow_uuid=$1`, [handle.getWorkflowUUID()]);
     expect(result.rows[0].recovery_attempts).toBe(String(LocalRecovery.maxRecoveryAttempts));
-    expect(result.rows[0].status).toBe(StatusString.RETRIES_EXCEEDED);
+    expect(result.rows[0].status).toBe(StatusString.SUCCESS);
   });
 
   test("local-recovery", async () => {

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -100,14 +100,14 @@ describe("recovery-tests", () => {
 
     let result = await systemDBClient.query<{status: string, recovery_attempts: number}>(`SELECT status, recovery_attempts FROM dbos.workflow_status WHERE workflow_uuid=$1`, [handle.getWorkflowUUID()]);
     expect(result.rows[0].recovery_attempts).toBe(String(LocalRecovery.maxRecoveryAttempts));
-    expect(result.rows[0].status).toBe(StatusString.NORETRY);
+    expect(result.rows[0].status).toBe(StatusString.RETRY_EXCEEDED);
 
     LocalRecovery.deadLetterResolve();
 
     await dbosExec.flushWorkflowResultBuffer();
     result = await systemDBClient.query<{status: string, recovery_attempts: number}>(`SELECT status, recovery_attempts FROM dbos.workflow_status WHERE workflow_uuid=$1`, [handle.getWorkflowUUID()]);
     expect(result.rows[0].recovery_attempts).toBe(String(LocalRecovery.maxRecoveryAttempts));
-    expect(result.rows[0].status).toBe(StatusString.NORETRY);
+    expect(result.rows[0].status).toBe(StatusString.RETRY_EXCEEDED);
   });
 
   test("local-recovery", async () => {

--- a/tests/recovery.test.ts
+++ b/tests/recovery.test.ts
@@ -15,6 +15,11 @@ describe("recovery-tests", () => {
   beforeAll(async () => {
     config = generateDBOSTestConfig();
     await setUpDBOSTestDb(config);
+  });
+
+  beforeEach(async () => {
+    testRuntime = await createInternalTestRuntime(undefined, config);
+    process.env.DBOS__VMID = ""
     systemDBClient = new Client({
       user: config.poolConfig.user,
       port: config.poolConfig.port,
@@ -22,11 +27,6 @@ describe("recovery-tests", () => {
       password: config.poolConfig.password,
       database: config.system_database,
     });
-  });
-
-  beforeEach(async () => {
-    testRuntime = await createInternalTestRuntime(undefined, config);
-    process.env.DBOS__VMID = ""
     await systemDBClient.connect();
   });
 


### PR DESCRIPTION
This PR implements a [dead letter queue](https://en.wikipedia.org/wiki/Dead_letter_queue) for workflows. If a workflow execution is recovered more than N times (50 by default, configurable in `WorkflowConfig`), it is placed in the dead letter queue and no further attempts will be made to recover it. A list of all workflows in the dead letter queue can be retrieved with `getWorkflows()`.

The goal of this change is to reduce the damage caused by buggy workflows that crash the execution environment. Without a dead letter queue, these will be retried indefinitely, wasting resources and disrupting other works. With this change, they are retried a maximum number of times then placed in the DLQ for manual investigation and restart.