### PR TITLE
Workflow Management CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "scripts": {
     "build": "tsc --project tsconfig.build.json && npm run --workspaces build",
     "build-fdb": "tsc --project tsconfig.build-fdb.json && npm run --workspaces build",
-    "lint": "eslint --ignore-pattern src/foundationdb/ --ignore-pattern tests/foundationdb/ .",
-    "lint-fdb": "eslint .",
+    "lint": "eslint --ignore-pattern src/foundationdb/ --ignore-pattern tests/foundationdb/ --ignore-pattern **/coverage/ .",
+    "lint-fdb": "eslint --ignore-pattern **/coverage/ .",
     "setversion": "npm run --workspaces setversion && grunt setversion",
     "test": "npm run build && rm -rf packages/create/templates/hello-prisma/node_modules/ && npm run --workspaces test && npx prisma generate --schema tests/prisma/schema.prisma && jest --coverage --collectCoverageFrom='src/**/*' --collectCoverageFrom='!src/foundationdb/**/*' --detectOpenHandles --testPathIgnorePatterns=examples/* --testPathIgnorePatterns=packages/* --testPathIgnorePatterns=tests/foundationdb/*",
     "test-fdb": "npm run build-fdb && rm -rf packages/create/templates/hello-prisma/node_modules/ && npm run --workspaces test && npx prisma generate --schema tests/prisma/schema.prisma && jest --runInBand --coverage"

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -146,7 +146,7 @@ workflowCommands
 
 workflowCommands
   .command('cancel')
-  .description('Cancel a workflow, preventing it from being retried')
+  .description('Cancel a workflow so it is no longer automatically retried or restarted')
   .argument("<uuid>", "Target workflow UUID")
   .option("-d, --appDir <string>", "Specify the application root directory")
   .action(async (uuid: string, options: { appDir?: string }) => {

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -112,7 +112,7 @@ workflowCommands
   .option('-u, --user <string>', 'Retrieve workflows run by this user')
   .option('-s, --start-time <string>', 'Retrieve workflows starting after this timestamp (ISO 8601 format)')
   .option('-e, --end-time <string>', 'Retrieve workflows starting before this timestamp (ISO 8601 format)')
-  .option('-S, --status <string>', 'Retrieve workflows with this status (PENDING, SUCCESS, ERROR, or RETRIES_EXCEEDED)')
+  .option('-S, --status <string>', 'Retrieve workflows with this status (PENDING, SUCCESS, ERROR, RETRIES_EXCEEDED, or CANCELLED)')
   .option('--request', 'Retrieve workflow request information')
   .option("-d, --appDir <string>", "Specify the application root directory")
   .action(async (options: {limit?: string, appDir?: string, user?: string, startTime?: string, endTime?: string, status?: string, request: boolean}) => {

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -113,9 +113,10 @@ workflowCommands
   .option('-s, --start-time <string>', 'Retrieve workflows starting after this timestamp (ISO 8601 format)')
   .option('-e, --end-time <string>', 'Retrieve workflows starting before this timestamp (ISO 8601 format)')
   .option('-S, --status <string>', 'Retrieve workflows with this status (PENDING, SUCCESS, ERROR, RETRIES_EXCEEDED, or CANCELLED)')
+  .option('-v, --application-version <string>', 'Retrieve workflows with this application version')
   .option('--request', 'Retrieve workflow request information')
   .option("-d, --appDir <string>", "Specify the application root directory")
-  .action(async (options: { limit?: string, appDir?: string, user?: string, startTime?: string, endTime?: string, status?: string, request: boolean }) => {
+  .action(async (options: { limit?: string, appDir?: string, user?: string, startTime?: string, endTime?: string, status?: string, applicationVersion?: string, request: boolean }) => {
     const [dbosConfig, _] = parseConfigFile(options);
     if (options.status && !Object.values(StatusString).includes(options.status as typeof StatusString[keyof typeof StatusString])) {
       console.error("Invalid status: ", options.status);
@@ -126,7 +127,8 @@ workflowCommands
       authenticatedUser: options.user,
       startTime: options.startTime,
       endTime: options.endTime,
-      status: options.status as typeof StatusString[keyof typeof StatusString]
+      status: options.status as typeof StatusString[keyof typeof StatusString],
+      applicationVersion: options.applicationVersion,
     }
     const output = await listWorkflows(dbosConfig, input, options.request);
     console.log(JSON.stringify(output))

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -129,10 +129,9 @@ workflowCommands
     console.log(JSON.stringify(output))
   });
 
-/////////////////////////
-/* WORKFLOW MANAGEMENT */
-/////////////////////////
-
+/////////////
+/* PARSING */
+/////////////
 
 program.parse(process.argv);
 

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -107,12 +107,12 @@ const workflowCommands = program.command("workflow").alias("workflows").alias("w
 workflowCommands
   .command('list')
   .description('List workflows from your application')
-  .option('-l, --limit <number>', 'Limit the results returned')
+  .option('-l, --limit <number>', 'Limit the results returned', "10")
   .option("-d, --appDir <string>", "Specify the application root directory")
-  .action(async (options: {limit?: number, appDir?: string}) => {
+  .action(async (options: {limit?: string, appDir?: string}) => {
     const [dbosConfig, _] = parseConfigFile(options);
     const input: GetWorkflowsInput = {
-      limit: options.limit
+      limit: Number(options.limit)
     }
     const output = await listWorkflows(dbosConfig, input);
     console.log(JSON.stringify(output))

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -9,6 +9,8 @@ import { GlobalLogger } from '../telemetry/logs';
 import { TelemetryCollector } from '../telemetry/collector';
 import { TelemetryExporter } from '../telemetry/exporters';
 import { configure } from './configure';
+import { listWorkflows } from './workflow_management';
+import { GetWorkflowsInput } from '..';
 
 const program = new Command();
 
@@ -95,6 +97,31 @@ program
 program
   .command('rollback')
   .action(async () => { await runAndLog(rollbackMigration); });
+
+/////////////////////////
+/* WORKFLOW MANAGEMENT */
+/////////////////////////
+
+const workflowCommands = program.command("workflow").alias("workflows").alias("wf").description("Manage DBOS workflows");
+
+workflowCommands
+  .command('list')
+  .description('List workflows from your application')
+  .option('-l, --limit <number>', 'Limit the results returned')
+  .option("-d, --appDir <string>", "Specify the application root directory")
+  .action(async (options: {limit?: number, appDir?: string}) => {
+    const [dbosConfig, _] = parseConfigFile(options);
+    const input: GetWorkflowsInput = {
+      limit: options.limit
+    }
+    const output = await listWorkflows(dbosConfig, input);
+    console.log(JSON.stringify(output))
+  });
+
+/////////////////////////
+/* WORKFLOW MANAGEMENT */
+/////////////////////////
+
 
 program.parse(process.argv);
 

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -9,7 +9,7 @@ import { GlobalLogger } from '../telemetry/logs';
 import { TelemetryCollector } from '../telemetry/collector';
 import { TelemetryExporter } from '../telemetry/exporters';
 import { configure } from './configure';
-import { listWorkflows } from './workflow_management';
+import { getWorkflow, listWorkflows } from './workflow_management';
 import { GetWorkflowsInput } from '..';
 
 const program = new Command();
@@ -115,6 +115,17 @@ workflowCommands
       limit: options.limit
     }
     const output = await listWorkflows(dbosConfig, input);
+    console.log(JSON.stringify(output))
+  });
+
+workflowCommands
+  .command('get')
+  .description('Retrieve the status of a workflow')
+  .argument("<uuid>", "Target workflow UUID")
+  .option("-d, --appDir <string>", "Specify the application root directory")
+  .action(async (uuid: string, options: {appDir?: string}) => {
+    const [dbosConfig, _] = parseConfigFile(options);
+    const output = await getWorkflow(dbosConfig, uuid);
     console.log(JSON.stringify(output))
   });
 

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -156,7 +156,7 @@ workflowCommands
 
 workflowCommands
   .command('retry')
-  .description('Retry a workflow from where it left off with its existing UUID')
+  .description('Retry a workflow from the last step it executed, keeping its UUID')
   .argument("<uuid>", "Target workflow UUID")
   .option("-d, --appDir <string>", "Specify the application root directory")
   .action(async (uuid: string, options: { appDir?: string }) => {

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -163,7 +163,8 @@ workflowCommands
   .option("-d, --appDir <string>", "Specify the application root directory")
   .action(async (uuid: string, options: { appDir?: string }) => {
     const [dbosConfig, runtimeConfig] = parseConfigFile(options);
-    await reattemptWorkflow(dbosConfig, runtimeConfig, uuid, false);
+    const output = await reattemptWorkflow(dbosConfig, runtimeConfig, uuid, false);
+    console.log(`Workflow output: ${JSON.stringify(output)}`);
   });
 
 workflowCommands
@@ -173,7 +174,8 @@ workflowCommands
   .option("-d, --appDir <string>", "Specify the application root directory")
   .action(async (uuid: string, options: { appDir?: string }) => {
     const [dbosConfig, runtimeConfig] = parseConfigFile(options);
-    await reattemptWorkflow(dbosConfig, runtimeConfig, uuid, true);
+    const output = await reattemptWorkflow(dbosConfig, runtimeConfig, uuid, true);
+    console.log(`Workflow output: ${JSON.stringify(output)}`);
   });
 
 /////////////

--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -157,8 +157,8 @@ workflowCommands
   });
 
 workflowCommands
-  .command('retry')
-  .description('Retry a workflow from the last step it executed, keeping its UUID')
+  .command('resume')
+  .description('Resume a workflow from the last step it executed, keeping its UUID')
   .argument("<uuid>", "Target workflow UUID")
   .option("-d, --appDir <string>", "Specify the application root directory")
   .action(async (uuid: string, options: { appDir?: string }) => {

--- a/src/dbos-runtime/workflow_management.ts
+++ b/src/dbos-runtime/workflow_management.ts
@@ -50,3 +50,9 @@ export async function getWorkflow(config: DBOSConfig, workflowUUID: string, getR
   await systemDatabase.destroy();
   return info;
 }
+
+export async function cancelWorkflow(config: DBOSConfig, workflowUUID: string) {
+  const systemDatabase = new PostgresSystemDatabase(config.poolConfig, config.system_database, createLogger() as unknown as GlobalLogger)
+  await systemDatabase.setWorkflowStatus(workflowUUID, StatusString.CANCELLED)
+  await systemDatabase.destroy();
+}

--- a/src/dbos-runtime/workflow_management.ts
+++ b/src/dbos-runtime/workflow_management.ts
@@ -51,6 +51,7 @@ export async function getWorkflow(config: DBOSConfig, workflowUUID: string, getR
   return info;
 }
 
+// Cancelling a workflow prevents it from being recovered or restarting, but active executions are not halted.
 export async function cancelWorkflow(config: DBOSConfig, workflowUUID: string) {
   const systemDatabase = new PostgresSystemDatabase(config.poolConfig, config.system_database, createLogger() as unknown as GlobalLogger)
   await systemDatabase.setWorkflowStatus(workflowUUID, StatusString.CANCELLED)

--- a/src/dbos-runtime/workflow_management.ts
+++ b/src/dbos-runtime/workflow_management.ts
@@ -57,7 +57,7 @@ export async function getWorkflow(config: DBOSConfig, workflowUUID: string, getR
 // Cancelling a workflow prevents it from being automatically recovered, but active executions are not halted.
 export async function cancelWorkflow(config: DBOSConfig, workflowUUID: string) {
   const systemDatabase = new PostgresSystemDatabase(config.poolConfig, config.system_database, createLogger() as unknown as GlobalLogger)
-  await systemDatabase.setWorkflowStatus(workflowUUID, StatusString.CANCELLED)
+  await systemDatabase.setWorkflowStatus(workflowUUID, StatusString.CANCELLED, false)
   await systemDatabase.destroy();
 }
 
@@ -69,7 +69,7 @@ export async function reattemptWorkflow(config: DBOSConfig, runtimeConfig: DBOSR
   }
   await dbosExec.init(classes);
   if (!startNewWorkflow) {
-    await dbosExec.systemDatabase.setWorkflowStatus(workflowUUID, StatusString.PENDING);
+    await dbosExec.systemDatabase.setWorkflowStatus(workflowUUID, StatusString.PENDING, true);
   }
   const handle = await dbosExec.executeWorkflowUUID(workflowUUID, startNewWorkflow);
   const output = await handle.getResult();

--- a/src/dbos-runtime/workflow_management.ts
+++ b/src/dbos-runtime/workflow_management.ts
@@ -7,7 +7,7 @@ import { HTTPRequest } from "../context";
 
 export async function listWorkflows(config: DBOSConfig, input: GetWorkflowsInput, getRequest: boolean) {
   const systemDatabase = new PostgresSystemDatabase(config.poolConfig, config.system_database, createLogger() as unknown as GlobalLogger)
-  const workflowUUIDs = (await systemDatabase.getWorkflows(input)).workflowUUIDs;
+  const workflowUUIDs = (await systemDatabase.getWorkflows(input)).workflowUUIDs.reverse(); // Reverse so most recent entries are printed last
   const workflowInfos = await Promise.all(workflowUUIDs.map(async (i) => await getWorkflowInfo(systemDatabase, i, getRequest)))
   await systemDatabase.destroy();
   return workflowInfos;

--- a/src/dbos-runtime/workflow_management.ts
+++ b/src/dbos-runtime/workflow_management.ts
@@ -1,31 +1,33 @@
 import { createLogger } from "winston";
 import { DBOSConfig, GetWorkflowsInput, StatusString } from "..";
-import { PostgresSystemDatabase } from "../system_database";
+import { PostgresSystemDatabase, SystemDatabase } from "../system_database";
 import { GlobalLogger } from "../telemetry/logs";
 import { WorkflowStatus } from "../workflow";
 
 export async function listWorkflows(config: DBOSConfig, input: GetWorkflowsInput) {
   const systemDatabase = new PostgresSystemDatabase(config.poolConfig, config.system_database, createLogger() as unknown as GlobalLogger)
-  const workflows = await systemDatabase.getWorkflows(input);
+  const workflowUUIDs = (await systemDatabase.getWorkflows(input)).workflowUUIDs;
+  const workflowInfos = await Promise.all(workflowUUIDs.map(async (i) => await getWorkflowInfo(systemDatabase, i)))
   await systemDatabase.destroy();
-  return workflows;
+  return workflowInfos;
 }
 
 export type WorkflowInformation = WorkflowStatus & {
+  workflowUUID: string,
   input?: unknown[],
   output?: unknown,
   error?: unknown,
 }
 
-export async function getWorkflow(config: DBOSConfig, workflowUUID: string) {
-  const systemDatabase = new PostgresSystemDatabase(config.poolConfig, config.system_database, createLogger() as unknown as GlobalLogger)
+export async function getWorkflowInfo(systemDatabase: SystemDatabase, workflowUUID: string) {
   const info = await systemDatabase.getWorkflowStatus(workflowUUID) as WorkflowInformation;
+  info.workflowUUID = workflowUUID;
   if (info === null) {
-    return {}
+    return {};
   }
   const input = await systemDatabase.getWorkflowInputs(workflowUUID);
   if (input !== null) {
-    info.input = input
+    info.input = input;
   }
   if (info.status === StatusString.SUCCESS) {
     const result = await systemDatabase.getWorkflowResult(workflowUUID);
@@ -34,6 +36,12 @@ export async function getWorkflow(config: DBOSConfig, workflowUUID: string) {
     const result = await systemDatabase.getWorkflowResult(workflowUUID);
     info.error = result;
   }
+  return info;
+}
+
+export async function getWorkflow(config: DBOSConfig, workflowUUID: string) {
+  const systemDatabase = new PostgresSystemDatabase(config.poolConfig, config.system_database, createLogger() as unknown as GlobalLogger)
+  const info = await getWorkflowInfo(systemDatabase, workflowUUID);
   await systemDatabase.destroy();
   return info;
 }

--- a/src/dbos-runtime/workflow_management.ts
+++ b/src/dbos-runtime/workflow_management.ts
@@ -54,7 +54,7 @@ export async function getWorkflow(config: DBOSConfig, workflowUUID: string, getR
   return info;
 }
 
-// Cancelling a workflow prevents it from being recovered or restarting, but active executions are not halted.
+// Cancelling a workflow prevents it from being automatically recovered, but active executions are not halted.
 export async function cancelWorkflow(config: DBOSConfig, workflowUUID: string) {
   const systemDatabase = new PostgresSystemDatabase(config.poolConfig, config.system_database, createLogger() as unknown as GlobalLogger)
   await systemDatabase.setWorkflowStatus(workflowUUID, StatusString.CANCELLED)

--- a/src/dbos-runtime/workflow_management.ts
+++ b/src/dbos-runtime/workflow_management.ts
@@ -1,0 +1,11 @@
+import { createLogger } from "winston";
+import { DBOSConfig, GetWorkflowsInput } from "..";
+import { PostgresSystemDatabase } from "../system_database";
+import { GlobalLogger } from "../telemetry/logs";
+
+export async function listWorkflows(config: DBOSConfig, input: GetWorkflowsInput) {
+  const systemDatabase = new PostgresSystemDatabase(config.poolConfig, config.system_database, createLogger() as unknown as GlobalLogger)
+  const workflows = await systemDatabase.getWorkflows(input);
+  await systemDatabase.destroy();
+  return workflows;
+}

--- a/src/dbos-runtime/workflow_management.ts
+++ b/src/dbos-runtime/workflow_management.ts
@@ -21,7 +21,7 @@ export type WorkflowInformation = Omit<WorkflowStatus, 'request'> & {
   request?: HTTPRequest,
 }
 
-export async function getWorkflowInfo(systemDatabase: SystemDatabase, workflowUUID: string, getRequest: boolean) {
+async function getWorkflowInfo(systemDatabase: SystemDatabase, workflowUUID: string, getRequest: boolean) {
   const info = await systemDatabase.getWorkflowStatus(workflowUUID) as WorkflowInformation;
   info.workflowUUID = workflowUUID;
   if (info === null) {

--- a/src/dbos-runtime/workflow_management.ts
+++ b/src/dbos-runtime/workflow_management.ts
@@ -1,11 +1,39 @@
 import { createLogger } from "winston";
-import { DBOSConfig, GetWorkflowsInput } from "..";
+import { DBOSConfig, GetWorkflowsInput, StatusString } from "..";
 import { PostgresSystemDatabase } from "../system_database";
 import { GlobalLogger } from "../telemetry/logs";
+import { WorkflowStatus } from "../workflow";
 
 export async function listWorkflows(config: DBOSConfig, input: GetWorkflowsInput) {
   const systemDatabase = new PostgresSystemDatabase(config.poolConfig, config.system_database, createLogger() as unknown as GlobalLogger)
   const workflows = await systemDatabase.getWorkflows(input);
   await systemDatabase.destroy();
   return workflows;
+}
+
+export type WorkflowInformation = WorkflowStatus & {
+  input?: unknown[],
+  output?: unknown,
+  error?: unknown,
+}
+
+export async function getWorkflow(config: DBOSConfig, workflowUUID: string) {
+  const systemDatabase = new PostgresSystemDatabase(config.poolConfig, config.system_database, createLogger() as unknown as GlobalLogger)
+  const info = await systemDatabase.getWorkflowStatus(workflowUUID) as WorkflowInformation;
+  if (info === null) {
+    return {}
+  }
+  const input = await systemDatabase.getWorkflowInputs(workflowUUID);
+  if (input !== null) {
+    info.input = input
+  }
+  if (info.status === StatusString.SUCCESS) {
+    const result = await systemDatabase.getWorkflowResult(workflowUUID);
+    info.output = result;
+  } else if (info.status === StatusString.ERROR) {
+    const result = await systemDatabase.getWorkflowResult(workflowUUID);
+    info.error = result;
+  }
+  await systemDatabase.destroy();
+  return info;
 }

--- a/src/dbos-runtime/workflow_management.ts
+++ b/src/dbos-runtime/workflow_management.ts
@@ -72,6 +72,7 @@ export async function reattemptWorkflow(config: DBOSConfig, runtimeConfig: DBOSR
     await dbosExec.systemDatabase.setWorkflowStatus(workflowUUID, StatusString.PENDING);
   }
   const handle = await dbosExec.executeWorkflowUUID(workflowUUID, startNewWorkflow);
-  await handle.getResult();
+  const output = await handle.getResult();
   await dbosExec.destroy();
+  return output;
 }

--- a/src/foundationdb/fdb_system_database.ts
+++ b/src/foundationdb/fdb_system_database.ts
@@ -253,6 +253,10 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
     return value;
   }
 
+  setWorkflowStatus(_workflowUUID: string, _status: typeof StatusString[keyof typeof StatusString]): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+
   async getWorkflowResult<R>(workflowUUID: string): Promise<R> {
     const watch = await this.workflowStatusDB.getAndWatch(workflowUUID);
     let value = watch.value;

--- a/src/foundationdb/fdb_system_database.ts
+++ b/src/foundationdb/fdb_system_database.ts
@@ -253,7 +253,7 @@ export class FoundationDBSystemDatabase implements SystemDatabase {
     return value;
   }
 
-  setWorkflowStatus(_workflowUUID: string, _status: typeof StatusString[keyof typeof StatusString]): Promise<void> {
+  setWorkflowStatus(_workflowUUID: string, _status: typeof StatusString[keyof typeof StatusString], _resetRecoveryAttempts: boolean): Promise<void> {
     throw new Error("Method not implemented.");
   }
 

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -32,6 +32,7 @@ export interface SystemDatabase {
 
   getWorkflowStatus(workflowUUID: string, callerUUID?: string, functionID?: number): Promise<WorkflowStatus | null>;
   getWorkflowResult<R>(workflowUUID: string): Promise<R>;
+  setWorkflowStatus(workflowUUID: string, status: typeof StatusString[keyof typeof StatusString]): Promise<void>;
 
   sleepms(workflowUUID: string, functionID: number, duration: number): Promise<void>;
 
@@ -638,6 +639,10 @@ export class PostgresSystemDatabase implements SystemDatabase {
       await this.recordOperationOutput(callerUUID, functionID, value);
     }
     return value;
+  }
+
+  async setWorkflowStatus(workflowUUID: string, status: typeof StatusString[keyof typeof StatusString]): Promise<void> {
+    await this.pool.query(`UPDATE ${DBOSExecutor.systemDBSchemaName}.workflow_status SET status=$1 WHERE workflow_uuid=$2`, [status, workflowUUID]);
   }
 
   async getWorkflowStatus(workflowUUID: string, callerUUID?: string, functionID?: number): Promise<WorkflowStatus | null> {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -64,8 +64,8 @@ export interface WorkflowStatus {
 export interface GetWorkflowsInput {
   workflowName?: string; // The name of the workflow function
   authenticatedUser?: string; // The user who ran the workflow.
-  startTime?: string; // Timestamp in RFC 3339 format
-  endTime?: string; // Timestamp in RFC 3339 format
+  startTime?: string; // Timestamp in ISO 8601 format
+  endTime?: string; // Timestamp in ISO 8601 format
   status?: "PENDING" | "SUCCESS" | "ERROR" | "RETRIES_EXCEEDED"; // The status of the workflow.
   applicationVersion?: string; // The application version that ran this workflow.
   limit?: number; // Return up to this many workflows IDs. IDs are ordered by workflow creation time.

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -51,7 +51,7 @@ export interface WorkflowConfig {
 }
 
 export interface WorkflowStatus {
-  readonly status: string; // The status of the workflow.  One of PENDING, SUCCESS, or ERROR.
+  readonly status: string; // The status of the workflow.  One of PENDING, SUCCESS, ERROR, RETRIES_EXCEEDED, or CANCELLED.
   readonly workflowName: string; // The name of the workflow function.
   readonly workflowClassName: string; // The class name holding the workflow function.
   readonly workflowConfigName: string; // The name of the configuration, if the class needs configuration
@@ -66,7 +66,7 @@ export interface GetWorkflowsInput {
   authenticatedUser?: string; // The user who ran the workflow.
   startTime?: string; // Timestamp in ISO 8601 format
   endTime?: string; // Timestamp in ISO 8601 format
-  status?: "PENDING" | "SUCCESS" | "ERROR" | "RETRIES_EXCEEDED"; // The status of the workflow.
+  status?: "PENDING" | "SUCCESS" | "ERROR" | "RETRIES_EXCEEDED" | "CANCELLED"; // The status of the workflow.
   applicationVersion?: string; // The application version that ran this workflow.
   limit?: number; // Return up to this many workflows IDs. IDs are ordered by workflow creation time.
 }
@@ -90,6 +90,7 @@ export const StatusString = {
   SUCCESS: "SUCCESS",
   ERROR: "ERROR",
   RETRIES_EXCEEDED: "RETRIES_EXCEEDED",
+  CANCELLED: "CANCELLED",
 } as const;
 
 type WFFunc = (ctxt: WorkflowContext, ...args: any[]) => Promise<unknown>;

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -13,6 +13,7 @@ import request from "supertest";
 import { DBOSConfig } from "../src/dbos-executor";
 import { TestingRuntime, TestingRuntimeImpl, createInternalTestRuntime } from "../src/testing/testing_runtime";
 import { generateDBOSTestConfig, setUpDBOSTestDb } from "./helpers";
+import { WorkflowInformation, listWorkflows } from "../src/dbos-runtime/workflow_management";
 
 describe("workflow-management-tests", () => {
   const testTableName = "dbos_test_kv";
@@ -167,6 +168,21 @@ describe("workflow-management-tests", () => {
     workflowUUIDs = JSON.parse(response.text) as GetWorkflowsOutput;
     expect(workflowUUIDs.workflowUUIDs.length).toBe(10);
     expect(workflowUUIDs.workflowUUIDs).not.toContain(firstUUID);
+  });
+
+  test("getworkflows-cli", async () => {
+    const response = await request(testRuntime.getHandlersCallback()).post("/workflow/alice");
+    expect(response.statusCode).toBe(200);
+    expect(response.text).toBe("alice");
+
+    const input: GetWorkflowsInput = {
+      workflowName: "testWorkflow"
+    }
+    const infos = await listWorkflows(config, input, false);
+    expect(infos.length).toBe(1);
+    const info = infos[0] as WorkflowInformation;
+    expect(info.authenticatedUser).toBe("alice");
+    expect(info.workflowName).toBe("testWorkflow");
   });
 
   async function testAuthMiddleware(_ctx: MiddlewareContext) {

--- a/tests/workflow_management.test.ts
+++ b/tests/workflow_management.test.ts
@@ -13,7 +13,7 @@ import request from "supertest";
 import { DBOSConfig } from "../src/dbos-executor";
 import { TestingRuntime, TestingRuntimeImpl, createInternalTestRuntime } from "../src/testing/testing_runtime";
 import { generateDBOSTestConfig, setUpDBOSTestDb } from "./helpers";
-import { WorkflowInformation, cancelWorkflow, getWorkflow, listWorkflows, retryWorkflow } from "../src/dbos-runtime/workflow_management";
+import { WorkflowInformation, cancelWorkflow, getWorkflow, listWorkflows, reattemptWorkflow } from "../src/dbos-runtime/workflow_management";
 import { Client } from "pg";
 
 describe("workflow-management-tests", () => {
@@ -210,7 +210,7 @@ describe("workflow-management-tests", () => {
     expect(info).toEqual(getInfo);
   });
 
-  test("test-cancel-retry-workflow", async () => {
+  test("test-cancel-retry-restart", async () => {
     TestEndpoints.tries = 0;
     const dbosExec = (testRuntime as TestingRuntimeImpl).getDBOSExec();
 
@@ -226,11 +226,23 @@ describe("workflow-management-tests", () => {
     expect(TestEndpoints.tries).toBe(1);
 
     TestEndpoints.testResolve();
-    await retryWorkflow(config, null, handle.getWorkflowUUID());
+    await reattemptWorkflow(config, null, handle.getWorkflowUUID(), false); // Retry the workflow
     expect(TestEndpoints.tries).toBe(2);
     await handle.getResult();
 
     await dbosExec.flushWorkflowBuffers();
+    result = await systemDBClient.query<{status: string, recovery_attempts: number}>(`SELECT status, recovery_attempts FROM dbos.workflow_status WHERE workflow_uuid=$1`, [handle.getWorkflowUUID()]);
+    expect(result.rows[0].recovery_attempts).toBe(String(1));
+    expect(result.rows[0].status).toBe(StatusString.SUCCESS);
+
+    await reattemptWorkflow(config, null, handle.getWorkflowUUID(), true); // Restart the workflow
+    expect(TestEndpoints.tries).toBe(3);
+    await dbosExec.flushWorkflowBuffers();
+    // Validate a new workflow is started and successful
+    result = await systemDBClient.query<{status: string, recovery_attempts: number}>(`SELECT status, recovery_attempts FROM dbos.workflow_status WHERE workflow_uuid!=$1`, [handle.getWorkflowUUID()]);
+    expect(result.rows[0].recovery_attempts).toBe(String(0));
+    expect(result.rows[0].status).toBe(StatusString.SUCCESS);
+    // Validate the original workflow status hasn't changed
     result = await systemDBClient.query<{status: string, recovery_attempts: number}>(`SELECT status, recovery_attempts FROM dbos.workflow_status WHERE workflow_uuid=$1`, [handle.getWorkflowUUID()]);
     expect(result.rows[0].recovery_attempts).toBe(String(1));
     expect(result.rows[0].status).toBe(StatusString.SUCCESS);


### PR DESCRIPTION
This PR adds a command-line interface for workflow management. There are five new commands:

- `npx dbos workflow list`: List workflows run by your application. Takes in parameters to filter on time, status, user, etc.
- `npx dbos workflow get <uuid>`: Retrieve the status of a workflow.
- `npx dbos workflow cancel <uuid>`: Cancel a workflow so it is no longer automatically retried or restarted . Active executions are not halted and the workflow can still be manually retried or restarted.
- `npx dbos workflow resume<uuid>`: Resume a workflow from the last step it executed, keeping its UUID.
- `npx dbos workflow restart<uuid>`: Resubmit a workflow, restarting it from the beginning with the same arguments but a new UUID.