### PR TITLE
check userdb is defined before calling destroy

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -164,7 +164,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
       const OTLPExporter = new TelemetryExporter(config.telemetry.OTLPExporter);
       this.telemetryCollector = new TelemetryCollector(OTLPExporter);
     } else {
-      // We always an collector to drain the signals queue, even if we don't have an exporter.
+      // We always setup a collector to drain the signals queue, even if we don't have an exporter.
       this.telemetryCollector = new TelemetryCollector();
     }
     this.logger = new Logger(this.telemetryCollector, this.config.telemetry?.logs);
@@ -372,7 +372,9 @@ export class DBOSExecutor implements DBOSExecutorContext {
       await sleepms(1000);
     }
     await this.systemDatabase.destroy();
-    await this.userDatabase.destroy();
+    if (this.userDatabase) {
+      await this.userDatabase.destroy();
+    }
     await this.logger.destroy();
   }
 


### PR DESCRIPTION
I noticed an exception being thrown when loading classes fail. See:

<img width="1259" alt="Screenshot 2024-07-01 at 09 31 55" src="https://github.com/dbos-inc/dbos-transact/assets/3437048/bf68c48e-7bce-402f-9494-9daed7944528">


When initializing the dbos runtime, we first construct the class, then load the applications classes through entry points, then call `init()`. Failure to load the class results in an undefined user database, which in turn results in an exception being throw. The exception pollutes the output and degrades UX.