### PR TITLE
display app archive size, in bytes, during deploy, in verbose mode

### DIFF
--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -57,7 +57,7 @@ async function createZipData(logger: CLILogger): Promise<string> {
   // Generate ZIP file as a Buffer
   logger.debug(`    Finalizing zip archive ...`);
   const buffer = await zip.generateAsync({ type: "nodebuffer" });
-  logger.debug(`    ... zip archive complete.`);
+  logger.debug(`    ... zip archive complete (${buffer.length} bytes).`);
   return buffer.toString("base64");
 }
 


### PR DESCRIPTION
As the title says. Convenient.