### PR TITLE
Fix class registration

### DIFF
--- a/src/dbos-runtime/debug.ts
+++ b/src/dbos-runtime/debug.ts
@@ -9,8 +9,8 @@ export async function debugWorkflow(dbosConfig: DBOSConfig, runtimeConfig: DBOSR
   try {
     const dbosExec = new DBOSExecutor(dbosConfig);
     dbosExec.logger.debug(`Loading classes from entrypoints: ${JSON.stringify(runtimeConfig.entrypoints)}`);
-    const classes = await DBOSRuntime.loadClasses(runtimeConfig.entrypoints);
-    await dbosExec.init(classes);
+    await DBOSRuntime.loadClasses(runtimeConfig.entrypoints);
+    await dbosExec.init();
 
     // Invoke the workflow in debug mode.
     const handle = await dbosExec.executeWorkflowUUID(workflowUUID);

--- a/src/dbos-runtime/runtime.ts
+++ b/src/dbos-runtime/runtime.ts
@@ -7,7 +7,6 @@ import path from 'node:path';
 import { Server } from 'http';
 import { pathToFileURL } from 'url';
 import { DBOSScheduler } from '../scheduler/scheduler';
-import { getAllRegisteredClasses } from '../decorators';
 
 interface ModuleExports {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -38,11 +37,8 @@ export class DBOSRuntime {
     try {
       this.dbosExec = new DBOSExecutor(this.dbosConfig);
       this.dbosExec.logger.debug(`Loading classes from entrypoints ${JSON.stringify(this.runtimeConfig.entrypoints)}`);
-      const classes = await DBOSRuntime.loadClasses(this.runtimeConfig.entrypoints);
-      for (const cls of getAllRegisteredClasses()) {
-        if (!classes.includes(cls)) classes.push(cls);
-      }
-      await this.dbosExec.init(classes);
+      await DBOSRuntime.loadClasses(this.runtimeConfig.entrypoints);
+      await this.dbosExec.init();
       const server = new DBOSHttpServer(this.dbosExec);
       this.servers = await server.listen(this.runtimeConfig.port);
       this.dbosExec.logRegisteredHTTPUrls();


### PR DESCRIPTION
This PR fixes an issue where the debug mode runtime didn't properly register all classes.

Also simplify the class registration logic everywhere -- we don't need to pass classes into `dbosExec.init()` anymore, because this `init()` function already registers all classes if no class specified.