### PR TITLE
handle AggregateError during DBOS executor init

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -354,6 +354,9 @@ export class DBOSExecutor implements DBOSExecutorContext {
       } else if (err instanceof Error) {
         const errorMessage = `Failed to initialize workflow executor: ${err.message}`;
         throw new DBOSInitializationError(errorMessage);
+      } else {
+        const errorMessage = `Failed to initialize workflow executor: ${err}`;
+        throw new DBOSInitializationError(errorMessage);
       }
     }
     this.initialized = true;

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -345,8 +345,16 @@ export class DBOSExecutor implements DBOSExecutorContext {
         await this.recoverPendingWorkflows();
       }
     } catch (err) {
-      (err as Error).message = `failed to initialize workflow executor: ${(err as Error).message}`;
-      throw new DBOSInitializationError(`${(err as Error).message}`);
+      if (err instanceof AggregateError) {
+        let combinedMessage = 'Failed to initialize workflow executor: ';
+        for (const error of err.errors) {
+          combinedMessage += `${(error as Error).message}; `;
+        }
+        throw new DBOSInitializationError(combinedMessage);
+      } else if (err instanceof Error) {
+        const errorMessage = `Failed to initialize workflow executor: ${(err as Error).message}`;
+        throw new DBOSInitializationError(errorMessage);
+      }
     }
     this.initialized = true;
 

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -355,7 +355,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
         const errorMessage = `Failed to initialize workflow executor: ${err.message}`;
         throw new DBOSInitializationError(errorMessage);
       } else {
-        const errorMessage = `Failed to initialize workflow executor: ${err}`;
+        const errorMessage = `Failed to initialize workflow executor: ${String(err)}`;
         throw new DBOSInitializationError(errorMessage);
       }
     }

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -352,7 +352,7 @@ export class DBOSExecutor implements DBOSExecutorContext {
         }
         throw new DBOSInitializationError(combinedMessage);
       } else if (err instanceof Error) {
-        const errorMessage = `Failed to initialize workflow executor: ${(err as Error).message}`;
+        const errorMessage = `Failed to initialize workflow executor: ${err.message}`;
         throw new DBOSInitializationError(errorMessage);
       }
     }


### PR DESCRIPTION
The `init()` call for a PG user database client can return aggregate errors. If we don't handle them properly, the returned error is missing a message:

<img width="981" alt="Screenshot 2024-07-14 at 09 19 09" src="https://github.com/user-attachments/assets/5060b9e1-76eb-415b-ae03-e3b1ef6314e6">

This PR adds a type check to parse `AggregateError`:

<img width="981" alt="Screenshot 2024-07-14 at 09 23 29" src="https://github.com/user-attachments/assets/73a9f420-6dde-4052-91c0-e57b1101e328">
