### PR TITLE
Handle system DB migration failure for forward compatibility

### DIFF
--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -138,8 +138,7 @@ export class PostgresSystemDatabase implements SystemDatabase {
     } catch (e) {
       const tableExists = await this.pool.query<ExistenceCheck>(`SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_schema = 'dbos' AND table_name = 'operation_outputs')`);
       if (tableExists.rows[0].exists) {
-        // If the table has been created by someone else. Ignore the error.
-        this.logger.warn(`System schema migration failed, may conflict with concurrent tasks: ${(e as Error).message}`);
+        this.logger.warn(`System database migration failed, you may be running an old version of DBOS Transact: ${(e as Error).message}`);
       } else {
         throw e;
       }

--- a/src/system_database.ts
+++ b/src/system_database.ts
@@ -86,9 +86,12 @@ export async function migrateSystemDatabase(systemPoolConfig: PoolConfig) {
       tableName: 'knex_migrations'
     }
   };
-  const knexDB = knex(knexConfig)
-  await knexDB.migrate.latest()
-  await knexDB.destroy()
+  const knexDB = knex(knexConfig);
+  try {
+    await knexDB.migrate.latest();
+  } finally {
+    await knexDB.destroy();
+  }
 }
 
 export class PostgresSystemDatabase implements SystemDatabase {
@@ -129,9 +132,21 @@ export class PostgresSystemDatabase implements SystemDatabase {
       // Create the DBOS system database.
       await pgSystemClient.query(`CREATE DATABASE "${this.systemDatabaseName}"`);
     }
-    await migrateSystemDatabase(this.systemPoolConfig);
+
+    try {
+      await migrateSystemDatabase(this.systemPoolConfig);
+    } catch (e) {
+      const tableExists = await this.pool.query<ExistenceCheck>(`SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_schema = 'dbos' AND table_name = 'operation_outputs')`);
+      if (tableExists.rows[0].exists) {
+        // If the table has been created by someone else. Ignore the error.
+        this.logger.warn(`System schema migration failed, may conflict with concurrent tasks: ${(e as Error).message}`);
+      } else {
+        throw e;
+      }
+    } finally {
+      await pgSystemClient.end();
+    }
     await this.listenForNotifications();
-    await pgSystemClient.end();
   }
 
   async destroy() {


### PR DESCRIPTION
This PR handles the system DB migration failure correctly so old app versions can still run on the new system DB schema. It is safe because we try not to make any backward incompatible changes.

Specifically, an error may happen if the old version detects a new migration in `knex_migrations` table but doesn't have the new migration file. With this PR, old versions can correctly proceed to run. This is important when we want to recover pending workflows under old app versions.