### PR TITLE
implement durable timeout in system database recv

### DIFF
--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -363,6 +363,8 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
 
   async recv<T>(_topic?: string | undefined, _timeoutSeconds?: number | undefined): Promise<T | null> {
     const functionID: number = this.functionIDGetIncrement();
+    //Increment once more to account for the timeoutFunctionID created by workflow
+    this.functionIDGetIncrement();
 
     // Original result must exist during replay.
     const check: T | null | DBOSNull = await this.#dbosExec.systemDatabase.checkOperationOutput<T | null>(this.workflowUUID, functionID);

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -839,13 +839,14 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
    */
   async recv<T>(topic?: string, timeoutSeconds: number = DBOSExecutor.defaultNotificationTimeoutSec): Promise<T | null> {
     const functionID: number = this.functionIDGetIncrement();
+    const timeoutFunctionID: number = this.functionIDGetIncrement();
 
     await this.#dbosExec.userDatabase.transaction(async (client: UserDatabaseClient) => {
       await this.flushResultBuffer(client);
     }, { isolationLevel: IsolationLevel.ReadCommitted });
     this.resultBuffer.clear();
 
-    return this.#dbosExec.systemDatabase.recv(this.workflowUUID, functionID, topic, timeoutSeconds);
+    return this.#dbosExec.systemDatabase.recv(this.workflowUUID, functionID, timeoutFunctionID, topic, timeoutSeconds);
   }
 
   /**

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -312,7 +312,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
   async #recordOutput<R>(query: QueryFunction, funcID: number, txnSnapshot: string, output: R, isKeyConflict: (error: unknown)=> boolean): Promise<string> {
     try {
       const serialOutput = DBOSJSON.stringify(output);
-      const rows = await query<transaction_outputs>("INSERT INTO dbos.transaction_outputs (workflow_uuid, function_id, output, txn_id, txn_snapshot, created_at) VALUES ($1, $2, $3, (select pg_current_xact_id_if_assigned()::text), $4, $5) RETURNING txn_id;", 
+      const rows = await query<transaction_outputs>("INSERT INTO dbos.transaction_outputs (workflow_uuid, function_id, output, txn_id, txn_snapshot, created_at) VALUES ($1, $2, $3, (select pg_current_xact_id_if_assigned()::text), $4, $5) RETURNING txn_id;",
         [this.workflowUUID, funcID, serialOutput, txnSnapshot, Date.now()]);
       return rows[0].txn_id;
     } catch (error) {
@@ -341,7 +341,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
   async #recordError(query: QueryFunction, funcID: number, txnSnapshot: string, err: Error, isKeyConflict: (error: unknown)=> boolean): Promise<void> {
     try {
       const serialErr = DBOSJSON.stringify(serializeError(err));
-      await query<transaction_outputs>("INSERT INTO dbos.transaction_outputs (workflow_uuid, function_id, error, txn_id, txn_snapshot, created_at) VALUES ($1, $2, $3, null, $4, $5) RETURNING txn_id;", 
+      await query<transaction_outputs>("INSERT INTO dbos.transaction_outputs (workflow_uuid, function_id, error, txn_id, txn_snapshot, created_at) VALUES ($1, $2, $3, null, $4, $5) RETURNING txn_id;",
         [this.workflowUUID, funcID, serialErr, txnSnapshot, Date.now()]);
     } catch (error) {
       if (isKeyConflict(error)) {
@@ -522,7 +522,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
       assumedRole: this.assumedRole,
     };
 
-    // Note, node-pg converts JS arrays to postgres array literals, so must call JSON.strigify on 
+    // Note, node-pg converts JS arrays to postgres array literals, so must call JSON.strigify on
     // args and bufferedResults before being passed to dbosExec.callProcedure
     const $args = [this.workflowUUID, funcId, this.presetUUID, $jsonCtx, null, JSON.stringify(args)];
     if (!readOnly) {
@@ -546,8 +546,8 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
       this.resultBuffer.clear();
     }
 
-    // if the stored proc returns an error, deserialize and throw it. 
-    // stored proc saves the error in tx_output before returning 
+    // if the stored proc returns an error, deserialize and throw it.
+    // stored proc saves the error in tx_output before returning
     if (error) {
       throw deserializeError(error);
     }
@@ -837,7 +837,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
    * If a topic is specified, retrieve the oldest message tagged with that topic.
    * Otherwise, retrieve the oldest message with no topic.
    */
-  async recv<T>(topic?: string, timeoutSeconds: number = DBOSExecutor.defaultNotificationTimeoutSec): Promise<T | null> {
+  async recv<T>(topic?: string, timeoutSeconds: number = DBOSExecutor.defaultNotificationTimeoutSec, timeoutDurable?: boolean): Promise<T | null> {
     const functionID: number = this.functionIDGetIncrement();
 
     await this.#dbosExec.userDatabase.transaction(async (client: UserDatabaseClient) => {
@@ -845,7 +845,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
     }, { isolationLevel: IsolationLevel.ReadCommitted });
     this.resultBuffer.clear();
 
-    return this.#dbosExec.systemDatabase.recv(this.workflowUUID, functionID, topic, timeoutSeconds);
+    return this.#dbosExec.systemDatabase.recv(this.workflowUUID, functionID, topic, timeoutSeconds, timeoutDurable);
   }
 
   /**

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -837,7 +837,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
    * If a topic is specified, retrieve the oldest message tagged with that topic.
    * Otherwise, retrieve the oldest message with no topic.
    */
-  async recv<T>(topic?: string, timeoutSeconds: number = DBOSExecutor.defaultNotificationTimeoutSec, timeoutDurable?: boolean): Promise<T | null> {
+  async recv<T>(topic?: string, timeoutSeconds: number = DBOSExecutor.defaultNotificationTimeoutSec): Promise<T | null> {
     const functionID: number = this.functionIDGetIncrement();
 
     await this.#dbosExec.userDatabase.transaction(async (client: UserDatabaseClient) => {
@@ -845,7 +845,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
     }, { isolationLevel: IsolationLevel.ReadCommitted });
     this.resultBuffer.clear();
 
-    return this.#dbosExec.systemDatabase.recv(this.workflowUUID, functionID, topic, timeoutSeconds, timeoutDurable);
+    return this.#dbosExec.systemDatabase.recv(this.workflowUUID, functionID, topic, timeoutSeconds);
   }
 
   /**

--- a/tests/oaoo.test.ts
+++ b/tests/oaoo.test.ts
@@ -143,7 +143,7 @@ describe("oaoo-tests", () => {
     const workflowUUID = uuidv1();
     const initTime = Date.now();
     await expect(testRuntime.invokeWorkflow(WorkflowOAOO, workflowUUID).sleepWorkflow(2)).resolves.toBeFalsy();
-    expect(Date.now() - initTime).toBeGreaterThanOrEqual(2000);
+    expect(Date.now() - initTime).toBeGreaterThanOrEqual(1950);
 
     // Rerunning should skip the sleep
     const startTime = Date.now();
@@ -155,7 +155,7 @@ describe("oaoo-tests", () => {
     const workflowUUID = uuidv1();
     const initTime = Date.now();
     await expect(testRuntime.invokeWorkflow(WorkflowOAOO, workflowUUID).recvWorkflow(2)).resolves.toBeFalsy();
-    expect(Date.now() - initTime).toBeGreaterThanOrEqual(2000);
+    expect(Date.now() - initTime).toBeGreaterThanOrEqual(1950);
 
     // Rerunning should skip the sleep
     const startTime = Date.now();

--- a/tests/oaoo.test.ts
+++ b/tests/oaoo.test.ts
@@ -130,18 +130,37 @@ describe("oaoo-tests", () => {
       await wfCtxt.sleep(durationSec);
       return;
     }
+
+    @Workflow()
+    static async recvWorkflow(wfCtxt: WorkflowContext, timeoutSeconds: number) {
+      await wfCtxt.recv('a-topic', timeoutSeconds);
+      return;
+    }
+
   }
 
   test("workflow-sleep-oaoo", async () => {
     const workflowUUID = uuidv1();
     const initTime = Date.now();
     await expect(testRuntime.invokeWorkflow(WorkflowOAOO, workflowUUID).sleepWorkflow(2)).resolves.toBeFalsy();
-    expect(Date.now() - initTime).toBeGreaterThanOrEqual(1500);
+    expect(Date.now() - initTime).toBeGreaterThanOrEqual(2000);
 
     // Rerunning should skip the sleep
     const startTime = Date.now();
     await expect(testRuntime.invokeWorkflow(WorkflowOAOO, workflowUUID).sleepWorkflow(2)).resolves.toBeFalsy();
-    expect(Date.now() - startTime).toBeLessThanOrEqual(1000);
+    expect(Date.now() - startTime).toBeLessThanOrEqual(200);
+  });
+
+  test("workflow-recv-oaoo", async () => {
+    const workflowUUID = uuidv1();
+    const initTime = Date.now();
+    await expect(testRuntime.invokeWorkflow(WorkflowOAOO, workflowUUID).recvWorkflow(2)).resolves.toBeFalsy();
+    expect(Date.now() - initTime).toBeGreaterThanOrEqual(2000);
+
+    // Rerunning should skip the sleep
+    const startTime = Date.now();
+    await expect(testRuntime.invokeWorkflow(WorkflowOAOO, workflowUUID).recvWorkflow(2)).resolves.toBeFalsy();
+    expect(Date.now() - startTime).toBeLessThanOrEqual(200);
   });
 
   test("workflow-oaoo", async () => {


### PR DESCRIPTION
This PR aims to address #451.
I only implemented durable timeout in the `recv` method for now so as to get your feedback before implementing
the functionality in the `getEvent` method.
