### PR TITLE
Suppress cloud CLI experimental warning

### DIFF
--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --no-warnings=ExperimentalWarning
 
 import { registerApp, listApps, deleteApp, deployAppCode, getAppLogs } from "./applications/index.js";
 import { Command } from "commander";


### PR DESCRIPTION
Our cloud CLI uses ESM. Due to some recent updates in our dependencies, we start seeing a warning like:
```
(node:85015) ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time
    at emitExperimentalWarning (node:internal/util:275:11)
    at ModuleLoader.jsonStrategy (node:internal/modules/esm/translators:464:3)
    at callTranslator (node:internal/modules/esm/loader:285:14)
    at ModuleLoader.moduleProvider (node:internal/modules/esm/loader:291:30)
```

This PR suppresses this experimental warning.