### PR TITLE
Fix executable

### DIFF
--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --no-warnings=ExperimentalWarning
+#!/usr/bin/env -S node --no-warnings=ExperimentalWarning
 
 import { registerApp, listApps, deleteApp, deployAppCode, getAppLogs } from "./applications/index.js";
 import { Command } from "commander";


### PR DESCRIPTION
According to https://github.com/nodejs/node/issues/30810
We need to use `#!/usr/bin/env -S node --no-warnings=ExperimentalWarning`  on Linux. Otherwise it hangs. This flag also works on other OS environments.