### PR TITLE
Clear scheduler timeout properly

### DIFF
--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -136,9 +136,9 @@ class DetachableLoop {
                   });
                 await Promise.race([
                     timeoutPromise,
-                    new Promise<void>((resolve) => this.interruptResolve = resolve)
+                    new Promise<void>((_, reject) => this.interruptResolve = reject)
                 ])
-                .catch(); // Interrupt sleep throws
+                .catch(() => {this.dbosExec.logger.debug("Scheduler loop interrupted!")}); // Interrupt sleep throws
                 clearTimeout(timer!);
             }
 

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -128,11 +128,18 @@ class DetachableLoop {
 
             if (sleepTime > 0) {
                 // Wait for either the timeout or an interruption
+                let timer: NodeJS.Timeout;
+                const timeoutPromise = new Promise<void>((resolve) => {
+                    timer = setTimeout(() => {
+                      resolve();
+                    }, sleepTime);
+                  });
                 await Promise.race([
-                    this.sleepms(sleepTime),
-                    new Promise<void>((_, reject) => this.interruptResolve = reject)
+                    timeoutPromise,
+                    new Promise<void>((resolve) => this.interruptResolve = resolve)
                 ])
                 .catch(); // Interrupt sleep throws
+                clearTimeout(timer!);
             }
 
             if (!this.isRunning) {

--- a/tests/scheduler/scheduler.test.ts
+++ b/tests/scheduler/scheduler.test.ts
@@ -44,4 +44,11 @@ class DBOSSchedTestClass {
 
         await ctxt.sleepms(2000);
     }
+
+    // This should run every 30 minutes. Making sure the testing runtime can correctly exit within a reasonable time.
+    @Scheduled({crontab: '*/30 * * * *'})
+    @Workflow()
+    static async scheduledLong(ctxt: WorkflowContext, _schedTime: Date, _startTime: Date) {
+        await ctxt.sleepms(100);
+    }
 }


### PR DESCRIPTION
This PR solves a bug where the runtime will hang as long as the longest scheduled interval (like a few hours). The solution is to properly clear the scheduler timeout.

Added a test to make sure the test can return within a reasonable time.