### PR TITLE
Default app_db_name to app name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13009,7 +13009,8 @@
         "update-notifier": "^7.0.0",
         "validator": "^13.11.0",
         "winston": "^3.12.0",
-        "winston-transport": "^4.7.0"
+        "winston-transport": "^4.7.0",
+        "yaml": "^2.5.0"
       },
       "bin": {
         "create": "dist/cli.js"
@@ -13085,6 +13086,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "packages/create/node_modules/yaml": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.0.tgz",
+      "integrity": "sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "packages/dbos-cloud": {

--- a/packages/create/init.ts
+++ b/packages/create/init.ts
@@ -114,7 +114,7 @@ function updateAppConfig(configFilePath: string, appName: string): void {
     const commentsContent = content.split(/\r?\n/).filter(line => line.startsWith('#')).join('\n') + '\n\n';
     const configFile = YAML.parse(content) as ConfigFile;
     // Change the app_db_name field to the sanitized appName, replacing dashes with underscores
-    let appDbName = appName.replace('-', '_');
+    let appDbName = appName.replaceAll('-', '_');
     if (appDbName.match(/^\d/)) {
       appDbName = "_" + appDbName; // Append an underscore if the name starts with a digit
     }

--- a/packages/create/init.ts
+++ b/packages/create/init.ts
@@ -4,12 +4,21 @@ import fs from 'fs'
 import { execSync } from 'child_process'
 import validator from 'validator';
 import { fileURLToPath } from 'url';
+import YAML from "yaml";
 
 interface CopyOption {
   rename?: (basename: string) => string;
 }
 
+// A stripped-down interface containing only the fields create needs to update
+interface ConfigFile {
+  database: {
+    app_db_name: string;
+  };
+}
+
 const identity = (x: string) => x;
+const dbosConfigFilePath = "dbos-config.yaml";
 
 export const copy = async (
   src: string,
@@ -98,6 +107,27 @@ function mergeGitIgnore(existingGISet: Set<string>, templateGISet: Set<string>):
     return joined.replaceAll('\n#','\n\n#');
 }
 
+function updateAppConfig(configFilePath: string, appName: string): void {
+  try {
+    const content = fs.readFileSync(configFilePath, 'utf-8');
+    const configFile = YAML.parse(content) as ConfigFile;
+    // Change the app_db_name field to the sanitized appName, replacing dashes with underscores
+    let appDbName = appName.replace('-', '_');
+    if (appDbName.match(/^\d/)) {
+      appDbName = "_" + appDbName; // Append an underscore if the name starts with a digit
+    }
+    configFile.database.app_db_name = appDbName;
+    const newContent = YAML.stringify(configFile);
+    fs.writeFileSync(configFilePath, newContent);
+  } catch (e) {
+    if (e instanceof Error) {
+      throw new Error(`Failed to load config from ${configFilePath}: ${e.message}`);
+    } else {
+      throw e;
+    }
+  }
+}
+
 function mergeGitignoreFiles(existingFilePath: string, templateFilePath: string, outputFilePath: string): void {
     const existingSet = loadGitignoreFile(existingFilePath);
     const templateSet = loadGitignoreFile(templateFilePath);
@@ -134,5 +164,6 @@ export async function init(appName: string, templateName: string) {
   execSync("npm install --no-fund --save @dbos-inc/dbos-sdk@latest --loglevel=error", {cwd: appName, stdio: 'inherit'})
   execSync("npm i --no-fund --loglevel=error", {cwd: appName, stdio: 'inherit'})
   execSync("npm install --no-fund --save-dev @dbos-inc/dbos-cloud@latest", {cwd: appName, stdio: 'inherit'})
+  updateAppConfig(path.join(appName, dbosConfigFilePath), appName);
   console.log("Application initialized successfully!")
 }

--- a/packages/create/init.ts
+++ b/packages/create/init.ts
@@ -110,6 +110,8 @@ function mergeGitIgnore(existingGISet: Set<string>, templateGISet: Set<string>):
 function updateAppConfig(configFilePath: string, appName: string): void {
   try {
     const content = fs.readFileSync(configFilePath, 'utf-8');
+    // Preserve the comments at the top
+    const commentsContent = content.split(/\r?\n/).filter(line => line.startsWith('#')).join('\n') + '\n\n';
     const configFile = YAML.parse(content) as ConfigFile;
     // Change the app_db_name field to the sanitized appName, replacing dashes with underscores
     let appDbName = appName.replace('-', '_');
@@ -117,7 +119,8 @@ function updateAppConfig(configFilePath: string, appName: string): void {
       appDbName = "_" + appDbName; // Append an underscore if the name starts with a digit
     }
     configFile.database.app_db_name = appDbName;
-    const newContent = YAML.stringify(configFile);
+
+    const newContent = commentsContent + YAML.stringify(configFile);
     fs.writeFileSync(configFilePath, newContent);
   } catch (e) {
     if (e instanceof Error) {

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -36,6 +36,7 @@
     "update-notifier": "^7.0.0",
     "validator": "^13.11.0",
     "winston": "^3.12.0",
-    "winston-transport": "^4.7.0"
+    "winston-transport": "^4.7.0",
+    "yaml": "^2.5.0"
   }
 }


### PR DESCRIPTION
This PR improves DX by updating the `app_db_name` field to the app name during `npx create`. This way, it prevents users from mistakenly using the same database for different apps.

Since Postgres database names "must begin with a letter or an underscore ( _ ). Subsequent characters in an identifier or key word can be letters, underscores, digits ( 0 - 9 )", we have to handle app names that don't follow this rule:
- Substitue dashes "-" to underscores "_".
- Append an underscore if the app name starts with a digit.