### PR TITLE
Implement durable timeout in workflow getEvent

### DIFF
--- a/src/debugger/debug_workflow.ts
+++ b/src/debugger/debug_workflow.ts
@@ -387,7 +387,8 @@ export class WorkflowContextDebug extends DBOSContextImpl implements WorkflowCon
 
   async getEvent<T>(_workflowUUID: string, _key: string, _timeoutSeconds?: number | undefined): Promise<T | null> {
     const functionID: number = this.functionIDGetIncrement();
-
+    //take into account the extra functionID increment from workflow
+    this.functionIDGetIncrement();
     // Original result must exist during replay.
     const check: T | null | DBOSNull = await this.#dbosExec.systemDatabase.checkOperationOutput<T | null>(this.workflowUUID, functionID);
     if (check === dbosNull) {

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -905,6 +905,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
    */
   getEvent<T>(targetUUID: string, key: string, timeoutSeconds: number = DBOSExecutor.defaultNotificationTimeoutSec): Promise<T | null> {
     const functionID: number = this.functionIDGetIncrement();
+    this.functionIDGetIncrement();
     return this.#dbosExec.systemDatabase.getEvent(targetUUID, key, timeoutSeconds, this.workflowUUID, functionID);
   }
 

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -905,8 +905,13 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
    */
   getEvent<T>(targetUUID: string, key: string, timeoutSeconds: number = DBOSExecutor.defaultNotificationTimeoutSec): Promise<T | null> {
     const functionID: number = this.functionIDGetIncrement();
-    this.functionIDGetIncrement();
-    return this.#dbosExec.systemDatabase.getEvent(targetUUID, key, timeoutSeconds, this.workflowUUID, functionID);
+    const timeoutFunctionID = this.functionIDGetIncrement();
+    const params = {
+      workflowUUID: this.workflowUUID,
+      functionID,
+      timeoutFunctionID
+    };
+    return this.#dbosExec.systemDatabase.getEvent(targetUUID, key, timeoutSeconds, params);
   }
 
   /**

--- a/tests/oaoo.test.ts
+++ b/tests/oaoo.test.ts
@@ -137,6 +137,12 @@ describe("oaoo-tests", () => {
       return;
     }
 
+    @Workflow()
+    static async getEventWorkflow(wfCtxt: WorkflowContext, timeoutSeconds: number) {
+      await wfCtxt.getEvent(uuidv1(), 'a-key', timeoutSeconds);
+      return;
+    }
+
   }
 
   test("workflow-sleep-oaoo", async () => {
@@ -160,6 +166,18 @@ describe("oaoo-tests", () => {
     // Rerunning should skip the sleep
     const startTime = Date.now();
     await expect(testRuntime.invokeWorkflow(WorkflowOAOO, workflowUUID).recvWorkflow(2)).resolves.toBeFalsy();
+    expect(Date.now() - startTime).toBeLessThanOrEqual(200);
+  });
+
+  test("workflow-getEvent-oaoo", async () => {
+    const workflowUUID = uuidv1();
+    const initTime = Date.now();
+    await expect(testRuntime.invokeWorkflow(WorkflowOAOO, workflowUUID).getEventWorkflow(2)).resolves.toBeFalsy();
+    expect(Date.now() - initTime).toBeGreaterThanOrEqual(1950);
+
+    // Rerunning should skip the sleep
+    const startTime = Date.now();
+    await expect(testRuntime.invokeWorkflow(WorkflowOAOO, workflowUUID).getEventWorkflow(2)).resolves.toBeFalsy();
     expect(Date.now() - startTime).toBeLessThanOrEqual(200);
   });
 


### PR DESCRIPTION
This PR aims to add durable timeout to the `getEvent` method of system_database