### PR TITLE
Fix Unintuitive Behavior

### DIFF
--- a/src/communicator.ts
+++ b/src/communicator.ts
@@ -8,7 +8,7 @@ export type Communicator<T extends unknown[], R> = (ctxt: CommunicatorContext, .
 export type CommunicatorFunction<T extends unknown[], R> = Communicator<T, R>;
 
 export interface CommunicatorConfig {
-  retriesAllowed?: boolean; // Should failures be retried? (default true)
+  retriesAllowed?: boolean; // Should failures be retried? (default false)
   intervalSeconds?: number; // Seconds to wait before the first retry attempt (default 1).
   maxAttempts?: number; // Maximum number of retry attempts (default 3). If errors occur more times than this, throw an exception.
   backoffRate?: number; // The multiplier by which the retry interval increases after every retry attempt (default 2).
@@ -33,7 +33,7 @@ export class CommunicatorContextImpl extends DBOSContextImpl implements Communic
   {
     super(commName, span, logger, workflowContext);
     this.functionID = functionID;
-    this.retriesAllowed = params.retriesAllowed ?? true;
+    this.retriesAllowed = params.retriesAllowed ?? false;
     this.intervalSeconds = params.intervalSeconds ?? 1;
     this.maxAttempts = params.maxAttempts ?? 3;
     this.backoffRate = params.backoffRate ?? 2;

--- a/src/communicator.ts
+++ b/src/communicator.ts
@@ -8,7 +8,7 @@ export type Communicator<T extends unknown[], R> = (ctxt: CommunicatorContext, .
 export type CommunicatorFunction<T extends unknown[], R> = Communicator<T, R>;
 
 export interface CommunicatorConfig {
-  retriesAllowed?: boolean; // Should failures be retried? (default false)
+  retriesAllowed?: boolean; // Should failures be retried? (default true)
   intervalSeconds?: number; // Seconds to wait before the first retry attempt (default 1).
   maxAttempts?: number; // Maximum number of retry attempts (default 3). If errors occur more times than this, throw an exception.
   backoffRate?: number; // The multiplier by which the retry interval increases after every retry attempt (default 2).
@@ -33,7 +33,7 @@ export class CommunicatorContextImpl extends DBOSContextImpl implements Communic
   {
     super(commName, span, logger, workflowContext);
     this.functionID = functionID;
-    this.retriesAllowed = params.retriesAllowed ?? false;
+    this.retriesAllowed = params.retriesAllowed ?? true;
     this.intervalSeconds = params.intervalSeconds ?? 1;
     this.maxAttempts = params.maxAttempts ?? 3;
     this.backoffRate = params.backoffRate ?? 2;

--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -675,8 +675,9 @@ export class DBOSExecutor implements DBOSExecutorContext {
           wCtxt.span.setStatus({ code: SpanStatusCode.OK });
         } else {
           // Record the error.
-          const e: Error = err as Error;
+          const e = err as Error & {dbos_already_logged?: boolean};
           this.logger.error(e);
+          e.dbos_already_logged = true
           if (wCtxt.isTempWorkflow) {
             internalStatus.name = `${DBOSExecutor.tempWorkflowName}-${wCtxt.tempWfOperationType}-${wCtxt.tempWfOperationName}`;
           }

--- a/src/httpServer/server.ts
+++ b/src/httpServer/server.ts
@@ -311,7 +311,10 @@ async checkPortAvailability(port: number, host: string): Promise<void> {
             oc.span.setStatus({ code: SpanStatusCode.OK });
           } catch (e) {
             if (e instanceof Error) {
-              oc.logger.error(e);
+              const annotated_e = e as Error & {dbos_already_logged?: boolean};
+              if (annotated_e.dbos_already_logged !== true) {
+                oc.logger.error(e);
+              }
               oc.span.setStatus({ code: SpanStatusCode.ERROR, message: e.message });
               let st = (e as DBOSResponseError)?.status || 500;
               const dbosErrorCode = (e as DBOSError)?.dbosErrorCode;

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -15,7 +15,7 @@ export enum SchedulerMode {
 
 export class SchedulerConfig {
     crontab: string = '* * * * *'; // Every minute
-    mode ?: SchedulerMode = SchedulerMode.ExactlyOncePerInterval;
+    mode ?: SchedulerMode = SchedulerMode.ExactlyOncePerIntervalWhenActive;
 }
 
 ////

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -781,7 +781,8 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
         try {
           result = await commFn.call(clsInst, ctxt, ...args);
         } catch (error) {
-          this.logger.error(error);
+          const e = error as Error
+          this.logger.error(`Communicator error being automatically retried. Attempt ${numAttempts} of ${ctxt.maxAttempts}. Error: ${e.message}`);
           span.addEvent(`Communicator attempt ${numAttempts + 1} failed`, { "retryIntervalSeconds": intervalSeconds, "error": (error as Error).message }, performance.now());
           if (numAttempts < ctxt.maxAttempts) {
             // Sleep for an interval, then increase the interval by backoffRate.

--- a/src/workflow.ts
+++ b/src/workflow.ts
@@ -782,7 +782,7 @@ export class WorkflowContextImpl extends DBOSContextImpl implements WorkflowCont
           result = await commFn.call(clsInst, ctxt, ...args);
         } catch (error) {
           const e = error as Error
-          this.logger.error(`Communicator error being automatically retried. Attempt ${numAttempts} of ${ctxt.maxAttempts}. Error: ${e.message}`);
+          this.logger.warn(`Communicator error being automatically retried. Attempt ${numAttempts} of ${ctxt.maxAttempts}. ${e.stack}`);
           span.addEvent(`Communicator attempt ${numAttempts + 1} failed`, { "retryIntervalSeconds": intervalSeconds, "error": (error as Error).message }, performance.now());
           if (numAttempts < ctxt.maxAttempts) {
             // Sleep for an interval, then increase the interval by backoffRate.

--- a/tests/failures.test.ts
+++ b/tests/failures.test.ts
@@ -179,7 +179,7 @@ class FailureTestClass {
     return await ctxt.invoke(FailureTestClass).testSerialError(maxRetry);
   }
 
-  @Communicator({ intervalSeconds: 1, maxAttempts: 2 })
+  @Communicator({ retriesAllowed: true, intervalSeconds: 1, maxAttempts: 2 })
   static async testFailCommunicator(ctxt: CommunicatorContext) {
     FailureTestClass.cnt++;
     if (ctxt.retriesAllowed && FailureTestClass.cnt !== ctxt.maxAttempts) {


### PR DESCRIPTION
This fixes unintuitive behaviors that sparked user complaints:

1. Scheduled workflows now default to `ExactlyOncePerIntervalWhenActive`. This means that if an executor is started after being deactivated for a long time, it does not try to "catch up" on past scheduled workflows. This is paired with a related bugfix (https://github.com/dbos-inc/dbos-transact/pull/577)  so this behavior and flag now work as intended.

2. Communicator retries now clearly emit error messages that explain what's going on, so they're no longer swallowed.
3. Fixed an issue where workflow errors were logged twice: once by the workflow and once by the handler.