### PR TITLE
Fix publish action

### DIFF
--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -33,12 +33,12 @@ jobs:
         uses: actions/setup-node@v4.0.2
         with:
           node-version: 20
+      - run: npm ci
       - name: Nerdbank.GitVersioning
         id: nbgv
         uses: dotnet/nbgv@v0.4.2
         with:
           stamp: ${{ matrix.package }}/package.json
-      - run: npm ci
       - run: cd ${{ matrix.package }}; npm run build
       - name: Publish release to npm
         uses: JS-DevTools/npm-publish@v3

--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-node@v4.0.2
         with:
           node-version: 20
-      - run: npm ci
+      - run: npm ci; npm run build
       - name: Nerdbank.GitVersioning
         id: nbgv
         uses: dotnet/nbgv@v0.4.2


### PR DESCRIPTION
Fix an issue in our Github action where the publish didn't build packages correctly.

Root cause was that I modified the dbos-sdk in package-lock.json to be:
```
"node_modules/@dbos-inc/dbos-sdk": {
      "resolved": "",
      "link": true
    },
```

So we must build the root package first.