### PR TITLE
Validate DB name when parsing dbos config

### DIFF
--- a/src/dbos-runtime/cli.ts
+++ b/src/dbos-runtime/cli.ts
@@ -201,11 +201,8 @@ if (!process.argv.slice(2).length) {
 //Finally, terminates the program with the exit code.
 export async function runAndLog(action: (configFile: ConfigFile, logger: GlobalLogger) => Promise<number> | number) {
   let logger = new GlobalLogger();
-  const configFile: ConfigFile | undefined = loadConfigFile(dbosConfigFilePath);
-  if (!configFile) {
-    logger.error(`Failed to parse ${dbosConfigFilePath}`);
-    process.exit(1);
-  }
+  const _ = parseConfigFile(); // Validate config file
+  const configFile = loadConfigFile(dbosConfigFilePath);
   let terminate = undefined;
   if (configFile.telemetry?.OTLPExporter) {
     logger = new GlobalLogger(new TelemetryCollector(new TelemetryExporter(configFile.telemetry.OTLPExporter)), configFile.telemetry?.logs);

--- a/src/dbos-runtime/config.ts
+++ b/src/dbos-runtime/config.ts
@@ -105,7 +105,7 @@ export function constructPoolConfig(configFile: ConfigFile) {
   };
 
   if (!poolConfig.database) {
-    throw new DBOSInitializationError(`DBOS configuration (dbos-config.yaml) does not contain application database name`);
+    throw new DBOSInitializationError(`DBOS configuration (${dbosConfigFilePath}) does not contain application database name`);
   }
 
   // Details on Postgres SSL/TLS modes: https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION
@@ -163,7 +163,7 @@ export function parseConfigFile(cliOptions?: ParseOptions, useProxy: boolean = f
 
   // Database field must exist
   if (!configFile.database) {
-    throw new DBOSInitializationError(`DBOS configuration (dbos-config.yaml) does not contain database config`);
+    throw new DBOSInitializationError(`DBOS configuration (${configFilePath}) does not contain database config`);
   }
 
   // Check for the database password
@@ -175,7 +175,7 @@ export function parseConfigFile(cliOptions?: ParseOptions, useProxy: boolean = f
       if (pgPassword) {
         configFile.database.password = pgPassword;
       } else {
-        throw new DBOSInitializationError(`DBOS configuration (dbos-config.yaml) does not contain database password`);
+        throw new DBOSInitializationError(`DBOS configuration (${configFilePath}) does not contain database password`);
       }
     }
   }
@@ -183,15 +183,15 @@ export function parseConfigFile(cliOptions?: ParseOptions, useProxy: boolean = f
   const schemaValidator = ajv.compile(dbosConfigSchema);
   if (!schemaValidator(configFile)) {
     const errorMessages = prettyPrintAjvErrors(schemaValidator);
-    throw new DBOSInitializationError(`dbos-config.yaml failed schema validation. ${errorMessages}`);
+    throw new DBOSInitializationError(`${configFilePath} failed schema validation. ${errorMessages}`);
   }
 
   if (configFile.language && configFile.language !== "node") {
-    throw new DBOSInitializationError(`dbos-config.yaml specifies invalid language ${configFile.language}`)
+    throw new DBOSInitializationError(`${configFilePath} specifies invalid language ${configFile.language}`)
   }
 
   if (!isValidDBname(configFile.database.app_db_name)) {
-    throw new DBOSInitializationError(`dbos-config.yaml specifies invalid app_db_name ${configFile.database.app_db_name}. Must be between 3 and 31 characters long and contain only lowercase letters, underscores, and digits (cannot begin with a digit).`);
+    throw new DBOSInitializationError(`${configFilePath} specifies invalid app_db_name ${configFile.database.app_db_name}. Must be between 3 and 31 characters long and contain only lowercase letters, underscores, and digits (cannot begin with a digit).`);
   }
 
   /*******************************/

--- a/src/dbos-runtime/migrate.ts
+++ b/src/dbos-runtime/migrate.ts
@@ -7,10 +7,6 @@ import { ExistenceCheck, migrateSystemDatabase } from "../system_database";
 import { schemaExistsQuery, txnOutputIndexExistsQuery, txnOutputTableExistsQuery } from "../user_database";
 
 export async function migrate(configFile: ConfigFile, logger: GlobalLogger) {
-  if (!configFile.database.password) {
-    logger.error(`DBOS configuration does not contain database password, please check your config file and retry!`);
-    return 1;
-  }
   const userDBName = configFile.database.app_db_name;
   logger.info(`Starting migration: creating database ${userDBName} if it does not exist`);
 

--- a/tests/dbos-runtime/config.test.ts
+++ b/tests/dbos-runtime/config.test.ts
@@ -20,7 +20,7 @@ describe("dbos-config", () => {
         port: 1234
         username: 'some user'
         password: \${PGPASSWORD}
-        app_db_name: 'some DB'
+        app_db_name: 'some_db'
         ssl: false
       application:
         payments_url: 'http://somedomain.com/payment'
@@ -52,7 +52,7 @@ describe("dbos-config", () => {
       expect(poolConfig.user).toBe("some user");
       expect(poolConfig.password).toBe(process.env.PGPASSWORD);
       expect(poolConfig.connectionTimeoutMillis).toBe(3000);
-      expect(poolConfig.database).toBe("some DB");
+      expect(poolConfig.database).toBe("some_db");
       expect(poolConfig.ssl).toBe(false);
 
       expect(dbosConfig.userDbclient).toBe(UserDatabaseName.KNEX);
@@ -149,7 +149,7 @@ describe("dbos-config", () => {
         port: 1234
         username: 'some user'
         password: \${PGPASSWORD}
-        app_db_name: 'some DB'
+        app_db_name: 'some_db'
         ssl: false
     `;
       jest.spyOn(utils, "readFileSync").mockReturnValueOnce(localMockDBOSConfigYamlString);
@@ -190,7 +190,7 @@ describe("dbos-config", () => {
           username: 'some user'
           password: \${PGPASSWORD}
           connectionTimeoutMillis: 3000
-          app_db_name: 'some DB'
+          app_db_name: 'some_db'
       `;
       jest.restoreAllMocks();
       jest.spyOn(utils, "readFileSync").mockReturnValue(localMockDBOSConfigYamlString);
@@ -211,7 +211,7 @@ describe("dbos-config", () => {
           username: 'some user'
           password: \${PGPASSWORD}
           connectionTimeoutMillis: 3000
-          app_db_name: 'some DB'
+          app_db_name: 'some_db'
         env:
           FOOFOO: barbar
           RANDENV: \${SOMERANDOMENV}
@@ -235,7 +235,7 @@ describe("dbos-config", () => {
           username: 'some user'
           password: \${PGPASSWORD}
           connectionTimeoutMillis: 3000
-          app_db_name: 'some DB'
+          app_db_name: 'some_db'
           ssl: true
         env:
           FOOFOO: barbar
@@ -254,7 +254,7 @@ describe("dbos-config", () => {
           username: 'some user'
           password: \${PGPASSWORD}
           connectionTimeoutMillis: 3000
-          app_db_name: 'some DB'
+          app_db_name: 'some_db'
         env:
           FOOFOO: barbar
       `;
@@ -272,7 +272,7 @@ describe("dbos-config", () => {
           username: 'some user'
           password: \${PGPASSWORD}
           connectionTimeoutMillis: 3000
-          app_db_name: 'some DB'
+          app_db_name: 'some_db'
         env:
           FOOFOO: barbar
       `;
@@ -300,7 +300,7 @@ describe("dbos-config", () => {
         userffname: 'some user'
         passffword: \${PGPASSWORD}
         connfectionTimeoutMillis: 3000
-        app_dfb_name: 'some DB'
+        app_dfb_name: 'some_db'
     `;
       jest.restoreAllMocks();
       jest.spyOn(utils, "readFileSync").mockReturnValue(localMockDBOSConfigYamlString);
@@ -315,7 +315,7 @@ describe("dbos-config", () => {
           username: 'dbos'
           password: \${PGPASSWORD}
           connectionTimeoutMillis: 3000
-          app_db_name: 'some DB'
+          app_db_name: 'some_db'
         env:
           FOOFOO: barbar
       `;
@@ -333,7 +333,7 @@ describe("dbos-config", () => {
           port: 1234
           username: 'some user'
           password: \${PGPASSWORD}
-          app_db_name: 'some DB'
+          app_db_name: 'some_db'
       `;
       jest.restoreAllMocks();
       jest.spyOn(utils, "readFileSync").mockReturnValue(localMockDBOSConfigYamlString);
@@ -345,8 +345,25 @@ describe("dbos-config", () => {
       expect(poolConfig.port).toBe(1234);
       expect(poolConfig.user).toBe("some user");
       expect(poolConfig.password).toBe("PROXY-MODE"); // Should be set to "PROXY-MODE"
-      expect(poolConfig.database).toBe("some DB");
+      expect(poolConfig.database).toBe("some_db");
       process.env.PGPASSWORD = dbPassword;
+    });
+
+    test("parseConfigFile throws on an invalid db name", async () => {
+      const invalidNames = ["some_DB", "123db", "db", "very_very_very_long_database_name", "largeDB"];
+      for (const dbName of invalidNames) {
+        const localMockDBOSConfigYamlString = `
+          database:
+              hostname: 'some host'
+              port: 1234
+              username: 'some user'
+              password: \${PGPASSWORD}
+              app_db_name: '${dbName}'
+        `;
+        jest.restoreAllMocks();
+        jest.spyOn(utils, "readFileSync").mockReturnValue(localMockDBOSConfigYamlString);
+        expect(() => parseConfigFile(mockCLIOptions)).toThrow(DBOSInitializationError);
+      }
     });
   });
 });


### PR DESCRIPTION
Make sure Transact enforces the same DB name validation rules as in DBOS Cloud.