### PR TITLE
Fix TypeORM Entities

### DIFF
--- a/src/dbos-executor.ts
+++ b/src/dbos-executor.ts
@@ -339,9 +339,11 @@ export class DBOSExecutor implements DBOSExecutorContext {
         /**
          * With TSORM, we take an array of entities (Function[]) and add them to this.entities:
          */
-        if (Array.isArray(reg.ormEntities) && reg.ormEntities.length > 0) {
-          this.entities = (this.entities as any[]).concat(reg.ormEntities as any[]);
-          length = reg.ormEntities.length;
+        if (Array.isArray(reg.ormEntities)) {
+          if (reg.ormEntities.length > 0) {
+            this.entities = (this.entities as any[]).concat(reg.ormEntities as any[]);
+            length = reg.ormEntities.length;
+          }
         } else {
           /**
            * With Drizzle, we need to take an object of entities, since the object keys are used to access the entities from ctx.client.query:

--- a/tests/drizzle.test.ts
+++ b/tests/drizzle.test.ts
@@ -35,6 +35,11 @@ const testTable = pgTable(testTableName, {
 
 let insertCount = 0;
 
+@OrmEntities()
+export class NoEntities {
+
+}
+
 @OrmEntities({ testTable })
 class TestClass {
   @Transaction()

--- a/tests/typeorm.test.ts
+++ b/tests/typeorm.test.ts
@@ -38,6 +38,11 @@ let globalCnt = 0;
 
 type TestTransactionContext = TransactionContext<EntityManager>;
 
+@OrmEntities()
+export class NoEntities {
+
+}
+
 @OrmEntities([KV])
 class KVController {
   @Transaction()


### PR DESCRIPTION
Separate TypeORM and Drizzle entities to fix a bug where a blank `@ORMEntities` decorator would disallow registering further entities.