### PR TITLE
Simplify dbos-cloud app deploy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13214,6 +13214,7 @@
       "version": "0.0.0-placeholder",
       "license": "MIT",
       "dependencies": {
+        "@inquirer/prompts": "^5.3.8",
         "axios": "^1.7.4",
         "chalk": "4.1.2",
         "commander": "^12.0.0",

--- a/packages/create/templates/hello/src/operations.ts
+++ b/packages/create/templates/hello/src/operations.ts
@@ -13,7 +13,7 @@ export class Hello {
   static async readme(_ctxt: HandlerContext) {
     const readme = `<html><body><p>
            Welcome to the DBOS Hello App!<br><br>
-           Visit the route /greeting/:name to be greeted!<br>' +
+           Visit the route /greeting/:name to be greeted!<br>
            For example, visit <a href="/greeting/dbos">/greeting/dbos</a>.<br>
            The counter increments with each page visit.<br>
            If you visit a new name like <a href="/greeting/alice">/greeting/alice</a>, the counter starts at 1.

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -133,8 +133,9 @@ export async function deployAppCode(
       return 1;
     }
     // Register the app
-    // TODO: Prompt the user to choose whether to enable time travel for their app?
-    await registerApp(userDBName, host, false, appName);
+    // TODO: add a flag to enable time travel?
+    const enableTimeTravel = false
+    await registerApp(userDBName, host, enableTimeTravel, appName);
 
   }
 

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -293,13 +293,13 @@ async function chooseAppDBServer(logger: Logger, host: string, userCredentials: 
   let userDBName = "";
   if (userDBs.length === 0) {
     // If not, prompt the user to provision one.
-    logger.info("No database found, provisioning a database server...");
+    logger.info("No database found, provisioning a database instance (server)...");
     userDBName = await input({
-      message: "Database server name?",
+      message: "Database instance name?",
       default: `${userCredentials.userName}-db-server`,
     });
     // Use a default user name and auto generated password.
-    const appDBUserName = "dbosapp_default";
+    const appDBUserName = "dbos_user";
     const appDBPassword = Buffer.from(Math.random().toString()).toString("base64");
     const res = await createUserDb(host, userDBName, appDBUserName, appDBPassword, true);
     if (res !== 0) {
@@ -308,7 +308,7 @@ async function chooseAppDBServer(logger: Logger, host: string, userCredentials: 
   } else if (userDBs.length > 1) {
     // If there is more than one database instances, prompt the user to select one.
     userDBName = await select({
-      message: "Choose a database server for this app:",
+      message: "Choose a database instance for this app:",
       choices: userDBs.map((db) => ({
         name: db.PostgresInstanceName,
         value: db.PostgresInstanceName,
@@ -317,7 +317,7 @@ async function chooseAppDBServer(logger: Logger, host: string, userCredentials: 
   } else {
     // Use the only available database server.
     userDBName = userDBs[0].PostgresInstanceName;
-    logger.info(`Using database server: ${userDBName}`);
+    logger.info(`Using database instance: ${userDBName}`);
   }
   return userDBName;
 }

--- a/packages/dbos-cloud/package.json
+++ b/packages/dbos-cloud/package.json
@@ -25,6 +25,7 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
+    "@inquirer/prompts": "^5.3.8",
     "axios": "^1.7.4",
     "chalk": "4.1.2",
     "commander": "^12.0.0",


### PR DESCRIPTION
This PR aims to reduce DBOS Cloud app deploy to a single command.
- First, check if the app is registered or not. If so, proceed to the normal deploy (this PR is fully backward compatible).
- If the app is not registered, then select a database server to use for this app.
  - List all database servers for the current user.
  - If the user doesn't have any database, then prompt to provision one.
  - If the user has more than one database servers, then prompt to choose one.
  - If the user has only one database server, then use it.
- Finally, register the app and deploy normally.

Discussion:
- Currently, it uses a default PG role name `dbosapp_default` and a generated password. Do we want user input for those?