### PR TITLE
Fix broken shebang on Windows (#600)

### DIFF
--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S node --no-warnings=ExperimentalWarning
+#!/usr/bin/env node
 
 import { registerApp, listApps, deleteApp, deployAppCode, getAppLogs } from "./applications/index.js";
 import { Command } from "commander";


### PR DESCRIPTION
The warning is no longer appearing and the shebang is broken on Windows.