### PR TITLE
Fix deploy app_db_name check

### DIFF
--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -154,7 +154,7 @@ export async function deployAppCode(
     }
 
     // Make sure the app database is the same.
-    if (dbosConfig.database.app_db_name !== appRegistered.ApplicationDatabaseName) {
+    if (appRegistered.ApplicationDatabaseName && (dbosConfig.database.app_db_name !== appRegistered.ApplicationDatabaseName)) {
       logger.error(`Application ${chalk.bold(appName)} is deployed with app_db_name ${chalk.bold(appRegistered.ApplicationDatabaseName)}, but ${dbosConfigFilePath} specifies ${chalk.bold(dbosConfig.database.app_db_name)}. Please update the app_db_name field in ${dbosConfigFilePath} to match the database name.`);
       return 1;
     }


### PR DESCRIPTION
For backward compatibility, don't check the app's DB name if it doesn't exist.