### PR TITLE
Don't Bundle Virtual Environments When Deploying Python Apps

### DIFF
--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -52,7 +52,7 @@ async function createZipData(logger: CLILogger): Promise<string> {
   const files = await fg(globPattern, {
     dot: true,
     onlyFiles: true,
-    ignore: [`**/${dbosEnvPath}/**`, "**/node_modules/**", "**/dist/**", "**/.git/**", `**/${dbosConfigFilePath}`],
+    ignore: [`**/${dbosEnvPath}/**`, "**/node_modules/**", "**/dist/**", "**/.git/**", `**/${dbosConfigFilePath}`, "**/venv/**", "**/.venv/**"],
   });
 
   files.forEach((file) => {


### PR DESCRIPTION
The venv should not be shipped with the application code.