### PR TITLE
Recommend Globally Installing Cloud CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9889,9 +9889,10 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"

--- a/packages/dbos-cloud/applications/deploy-app-code.ts
+++ b/packages/dbos-cloud/applications/deploy-app-code.ts
@@ -87,7 +87,7 @@ export async function deployAppCode(
   userDBName: string | undefined = undefined, // Used for registering the app
   enableTimeTravel: boolean = false
 ): Promise<number> {
-  const startTime = Date.now(); 
+  const startTime = Date.now();
   const logger = getLogger(verbose);
   logger.debug("Getting cloud credentials...");
   const userCredentials = await getCloudCredentials(host, logger);
@@ -207,7 +207,7 @@ export async function deployAppCode(
       if (count % 50 === 0) {
         logger.info(`Waiting for ${appName} with version ${deployOutput.ApplicationVersion} to be available`);
         if (count > 200) {
-          logger.info(`If ${appName} takes too long to become available, check its logs with 'npx dbos-cloud applications logs'`);
+          logger.info(`If ${appName} takes too long to become available, check its logs with 'dbos-cloud applications logs'`);
         }
       }
       if (count > 1800) {
@@ -242,7 +242,7 @@ export async function deployAppCode(
       handleAPIErrors(errorLabel, axiosError);
       const resp: CloudAPIErrorResponse = axiosError.response?.data;
       if (resp.message.includes(`application ${appName} not found`)) {
-        console.log(chalk.red("Did you register this application? Hint: run `npx dbos-cloud app register -d <database-instance-name>` to register your app and try again"));
+        console.log(chalk.red("Did you register this application? Hint: run `dbos-cloud app register -d <database-instance-name>` to register your app and try again"));
       }
     } else {
       logger.error(`${errorLabel}: ${(e as Error).message}`);

--- a/packages/dbos-cloud/applications/register-app.ts
+++ b/packages/dbos-cloud/applications/register-app.ts
@@ -43,7 +43,7 @@ export async function registerApp(dbname: string, host: string, enableTimetravel
       handleAPIErrors(errorLabel, axiosError);
       const resp: CloudAPIErrorResponse = axiosError.response?.data;
       if (resp.message.includes(`database ${dbname} not found`)) {
-        console.log(chalk.red(`Did you provision this database? Hint: run \`npx dbos-cloud db provision ${dbname} -U <database-username>\` to provision the database and try again`));
+        console.log(chalk.red(`Did you provision this database? Hint: run \`dbos-cloud db provision ${dbname} -U <database-username>\` to provision the database and try again`));
       }
     } else {
       logger.error(`${errorLabel}: ${(e as Error).message}`);

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -37,7 +37,7 @@ try {
   DBOS Cloud CLI Update available ${chalk.gray(notifier.update.current)} →  ${chalk.green(notifier.update.latest)}
 
   To upgrade the DBOS Cloud CLI to the latest version, run the following command:
-  ${chalk.cyan("`npm i --save-dev @dbos-inc/dbos-cloud@latest`")}
+  ${chalk.cyan("`npm i -g @dbos-inc/dbos-cloud@latest`")}
 
   ${chalk.yellow("-----------------------------------------------------------------------------------------")}`);
   }

--- a/packages/dbos-cloud/cli.ts
+++ b/packages/dbos-cloud/cli.ts
@@ -136,7 +136,7 @@ applicationCommands
   .description("Deploy this application to the cloud and run associated database rollback commands")
   .argument("[string]", "application name (Default: name from package.json)")
   .action(async (appName: string | undefined) => {
-    console.warn(`npx dbos-cloud app rollback is deprecated. Please use 'npx dbos-cloud db connect' instead and run rollback commands locally`);
+    console.warn(`dbos-cloud app rollback is deprecated. Please use 'dbos-cloud db connect' instead and run rollback commands locally`);
     const exitCode = await deployAppCode(DBOSCloudHost, true, null, false, null, appName);
     process.exit(exitCode);
   });

--- a/packages/dbos-cloud/users/register.ts
+++ b/packages/dbos-cloud/users/register.ts
@@ -4,7 +4,7 @@ export async function registerUser(username: string, secret: string | undefined,
   const logger = getLogger();
   const credentials = await getCloudCredentials(host, logger, username, secret);
   if (credentials.userName !== username) {
-    logger.warn(`You are trying to register ${username}, but are currently authenticated as ${credentials.userName}. To register a new user, please run "npx dbos-cloud logout".`)
+    logger.warn(`You are trying to register ${username}, but are currently authenticated as ${credentials.userName}. To register a new user, please run "dbos-cloud logout".`)
   }
   return 0;
 }


### PR DESCRIPTION
As the Cloud CLI is now cross-language, handling both TypeScript and Python apps, we recommend installing it globally and accessing it as `dbos-cloud` instead of `npx dbos-cloud`.